### PR TITLE
Follow-up fixes for main CD dataprep remote flow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -387,7 +387,11 @@ jobs:
             echo "bastion_input_host_resolves=yes"
           else
             echo "bastion_input_host_resolves=no"
-            exit 1
+            # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
+            BASTION_HOST_RESOLVED=163.172.185.238
+            BASTION_SOURCE=fallback_ip
+            echo "bastion_source=${BASTION_SOURCE}"
+            echo "bastion_input_host_kind=ip"
           fi
           printf '%s\n' \
             "Host * !${BASTION_HOST_RESOLVED}" \
@@ -561,6 +565,10 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
+          if ! getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
+            # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
+            BASTION_HOST_RESOLVED=163.172.185.238
+          fi
           printf '%s\n' \
             "Host * !${BASTION_HOST_RESOLVED}" \
             "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -335,7 +335,18 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          cat > "${HOME}/.ssh/config" <<EOF
+          Host bastion
+            HostName ${BASTION_HOST}
+            User ${BASTION_USER}
+            IdentityFile ${HOME}/.ssh/id_rsa_matchID
+            IdentitiesOnly yes
+            StrictHostKeyChecking no
+          EOF
+          chmod 600 "${HOME}/.ssh/config"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Check dataprep year snapshot
         run: make -C packages/deces-dataprep clean full-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
@@ -353,7 +364,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${CD_GIT_BRANCH}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${CD_GIT_BRANCH}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -441,7 +452,18 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          cat > "${HOME}/.ssh/config" <<EOF
+          Host bastion
+            HostName ${BASTION_HOST}
+            User ${BASTION_USER}
+            IdentityFile ${HOME}/.ssh/id_rsa_matchID
+            IdentitiesOnly yes
+            StrictHostKeyChecking no
+          EOF
+          chmod 600 "${HOME}/.ssh/config"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Deploy dev-deces.matchid.io
         run: |
@@ -453,7 +475,7 @@ jobs:
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV \
             REPOSITORY_BUCKET=$REPOSITORY_BUCKET_DEV \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
           make deploy-remote \
             GIT_BRANCH=$GIT_BRANCH \
             REMOTE_DEPLOY_BRANCH=main \
@@ -468,7 +490,7 @@ jobs:
             MMDB_TOKEN=$MMDB_TOKEN \
             NEW_RELIC_API_KEY=$NEW_RELIC_API_KEY NEW_RELIC_ACCOUNT_ID=$NEW_RELIC_ACCOUNT_ID NEW_RELIC_INGEST_KEY=$NEW_RELIC_INGEST_KEY \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -354,6 +354,28 @@ jobs:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+      - name: Debug dataprep bastion resolution
+        run: |
+          set -euo pipefail
+          RESOLVED_HOST="$(ssh -G bastion | awk '$1 == "hostname" { print $2; exit }')"
+          RESOLVED_USER="$(ssh -G bastion | awk '$1 == "user" { print $2; exit }')"
+          echo "bastion_user=${RESOLVED_USER}"
+          if [ -z "${RESOLVED_HOST}" ]; then
+            echo "bastion_host_kind=empty"
+            echo "bastion_host_resolves=no"
+            exit 1
+          fi
+          if printf '%s' "${RESOLVED_HOST}" | grep -Eq '^[0-9.]+$'; then
+            echo "bastion_host_kind=ip"
+          else
+            echo "bastion_host_kind=name"
+          fi
+          if getent hosts "${RESOLVED_HOST}" >/dev/null 2>&1; then
+            echo "bastion_host_resolves=yes"
+          else
+            echo "bastion_host_resolves=no"
+            exit 1
+          fi
       - name: Check dataprep year snapshot
         run: make -C packages/deces-dataprep clean full-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -370,7 +370,7 @@ jobs:
             printf '%s' "${value}"
           }
           BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
-          BASTION_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
+          BASTION_USER_RESOLVED=ubuntu
           BASTION_SOURCE=nginx
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
@@ -560,7 +560,7 @@ jobs:
             printf '%s' "${value}"
           }
           BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
-          BASTION_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
+          BASTION_USER_RESOLVED=ubuntu
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           test -n "${BASTION_HOST_RESOLVED}"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -394,8 +394,17 @@ jobs:
             echo "bastion_input_host_kind=ip"
           fi
           printf '%s\n' \
-            "Host * !${BASTION_HOST_RESOLVED}" \
-            "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \
+            "Host bastion" \
+            "  HostName ${BASTION_HOST_RESOLVED}" \
+            "  User ${BASTION_USER_RESOLVED}" \
+            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
+            "  IdentitiesOnly yes" \
+            "  StrictHostKeyChecking no" \
+            "  UserKnownHostsFile /dev/null" \
+            "Host * !bastion" \
+            "  ProxyJump bastion" \
+            "  StrictHostKeyChecking no" \
+            "  UserKnownHostsFile /dev/null" \
             > "${HOME}/.ssh/config"
           sed -n 'l' "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
@@ -408,16 +417,16 @@ jobs:
       - name: Debug dataprep bastion resolution
         run: |
           set -euo pipefail
-          PROXY_COMMAND="$(ssh -G -F "${HOME}/.ssh/config" 10.0.0.1 | awk '
-            $1 == "proxycommand" {
+          PROXY_ROUTE="$(ssh -G -F "${HOME}/.ssh/config" 10.0.0.1 | awk '
+            $1 == "proxyjump" || $1 == "proxycommand" {
               $1 = ""
               sub(/^ /, "")
               print
               exit
             }
           ')"
-          echo "proxy_command_present=$([ -n "${PROXY_COMMAND}" ] && echo yes || echo no)"
-          if [ -z "${PROXY_COMMAND}" ]; then
+          echo "proxy_route_present=$([ -n "${PROXY_ROUTE}" ] && echo yes || echo no)"
+          if [ -z "${PROXY_ROUTE}" ]; then
             exit 1
           fi
       - name: Check dataprep year snapshot
@@ -570,8 +579,17 @@ jobs:
             BASTION_HOST_RESOLVED=163.172.185.238
           fi
           printf '%s\n' \
-            "Host * !${BASTION_HOST_RESOLVED}" \
-            "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \
+            "Host bastion" \
+            "  HostName ${BASTION_HOST_RESOLVED}" \
+            "  User ${BASTION_USER_RESOLVED}" \
+            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
+            "  IdentitiesOnly yes" \
+            "  StrictHostKeyChecking no" \
+            "  UserKnownHostsFile /dev/null" \
+            "Host * !bastion" \
+            "  ProxyJump bastion" \
+            "  StrictHostKeyChecking no" \
+            "  UserKnownHostsFile /dev/null" \
             > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -357,8 +357,8 @@ jobs:
       - name: Debug dataprep bastion resolution
         run: |
           set -euo pipefail
-          RESOLVED_HOST="$(ssh -G bastion | awk '$1 == "hostname" { print $2; exit }')"
-          RESOLVED_USER="$(ssh -G bastion | awk '$1 == "user" { print $2; exit }')"
+          RESOLVED_HOST="$(ssh -G -F "${HOME}/.ssh/config" bastion | awk '$1 == "hostname" { print $2; exit }')"
+          RESOLVED_USER="$(ssh -G -F "${HOME}/.ssh/config" bastion | awk '$1 == "user" { print $2; exit }')"
           echo "bastion_user=${RESOLVED_USER}"
           if [ -z "${RESOLVED_HOST}" ]; then
             echo "bastion_host_kind=empty"
@@ -392,7 +392,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${CD_GIT_BRANCH}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${CD_GIT_BRANCH}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -509,7 +509,7 @@ jobs:
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV \
             REPOSITORY_BUCKET=$REPOSITORY_BUCKET_DEV \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
           make deploy-remote \
             GIT_BRANCH=$GIT_BRANCH \
             REMOTE_DEPLOY_BRANCH=main \
@@ -524,7 +524,7 @@ jobs:
             MMDB_TOKEN=$MMDB_TOKEN \
             NEW_RELIC_API_KEY=$NEW_RELIC_API_KEY NEW_RELIC_ACCOUNT_ID=$NEW_RELIC_ACCOUNT_ID NEW_RELIC_INGEST_KEY=$NEW_RELIC_INGEST_KEY \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -341,6 +341,11 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
+          if printf '%s' "${BASTION_HOST_RESOLVED}" | grep -Eq '^[0-9.]+$'; then
+            echo "bastion_input_host_kind=ip"
+          else
+            echo "bastion_input_host_kind=name"
+          fi
           printf '%s\n' \
             'Host bastion' \
             "  HostName ${BASTION_HOST_RESOLVED}" \
@@ -349,6 +354,7 @@ jobs:
             '  IdentitiesOnly yes' \
             '  StrictHostKeyChecking no' \
             > "${HOME}/.ssh/config"
+          sed -n 'l' "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -335,51 +335,53 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          BASTION_HOST_RESOLVED="$(sed -n 's/^export NGINX_HOST=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
-          BASTION_USER_RESOLVED="$(sed -n 's/^export NGINX_USER=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          ssh-agent -a /tmp/ssh_agent.sock > /dev/null
+          ssh-add "${HOME}/.ssh/id_rsa_matchID"
+          BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
+          BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"
+          BASTION_SOURCE=nginx
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
+          if [ -z "$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')" ]; then BASTION_SOURCE=bastion; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
+          echo "bastion_source=${BASTION_SOURCE}"
           if printf '%s' "${BASTION_HOST_RESOLVED}" | grep -Eq '^[0-9.]+$'; then
             echo "bastion_input_host_kind=ip"
           else
             echo "bastion_input_host_kind=name"
           fi
+          if getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
+            echo "bastion_input_host_resolves=yes"
+          else
+            echo "bastion_input_host_resolves=no"
+            exit 1
+          fi
           printf '%s\n' \
-            'Host bastion' \
-            "  HostName ${BASTION_HOST_RESOLVED}" \
-            "  User ${BASTION_USER_RESOLVED}" \
-            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
-            '  IdentitiesOnly yes' \
-            '  StrictHostKeyChecking no' \
+            "Host * !${BASTION_HOST_RESOLVED}" \
+            "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \
             > "${HOME}/.ssh/config"
           sed -n 'l' "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
+          NGINX_HOST: ${{ secrets.NGINX_HOST }}
+          NGINX_USER: ${{ secrets.NGINX_USER || 'ubuntu' }}
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Debug dataprep bastion resolution
         run: |
           set -euo pipefail
-          RESOLVED_HOST="$(ssh -G -F "${HOME}/.ssh/config" bastion | awk '$1 == "hostname" { print $2; exit }')"
-          RESOLVED_USER="$(ssh -G -F "${HOME}/.ssh/config" bastion | awk '$1 == "user" { print $2; exit }')"
-          echo "bastion_user=${RESOLVED_USER}"
-          if [ -z "${RESOLVED_HOST}" ]; then
-            echo "bastion_host_kind=empty"
-            echo "bastion_host_resolves=no"
-            exit 1
-          fi
-          if printf '%s' "${RESOLVED_HOST}" | grep -Eq '^[0-9.]+$'; then
-            echo "bastion_host_kind=ip"
-          else
-            echo "bastion_host_kind=name"
-          fi
-          if getent hosts "${RESOLVED_HOST}" >/dev/null 2>&1; then
-            echo "bastion_host_resolves=yes"
-          else
-            echo "bastion_host_resolves=no"
+          PROXY_COMMAND="$(ssh -G -F "${HOME}/.ssh/config" 10.0.0.1 | awk '
+            $1 == "proxycommand" {
+              $1 = ""
+              sub(/^ /, "")
+              print
+              exit
+            }
+          ')"
+          echo "proxy_command_present=$([ -n "${PROXY_COMMAND}" ] && echo yes || echo no)"
+          if [ -z "${PROXY_COMMAND}" ]; then
             exit 1
           fi
       - name: Check dataprep year snapshot
@@ -398,7 +400,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${CD_GIT_BRANCH}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${CD_GIT_BRANCH}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -413,6 +415,7 @@ jobs:
           SCW_SERVER_OPTS: ${{ secrets.SCW_SERVER_OPTS }}
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       - name: Export dataprep year snapshot metadata
         run: |
           make -C packages/deces-dataprep repository-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
@@ -486,22 +489,22 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          BASTION_HOST_RESOLVED="$(sed -n 's/^export NGINX_HOST=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
-          BASTION_USER_RESOLVED="$(sed -n 's/^export NGINX_USER=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          ssh-agent -a /tmp/ssh_agent.sock > /dev/null
+          ssh-add "${HOME}/.ssh/id_rsa_matchID"
+          BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
+          BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
           printf '%s\n' \
-            'Host bastion' \
-            "  HostName ${BASTION_HOST_RESOLVED}" \
-            "  User ${BASTION_USER_RESOLVED}" \
-            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
-            '  IdentitiesOnly yes' \
-            '  StrictHostKeyChecking no' \
+            "Host * !${BASTION_HOST_RESOLVED}" \
+            "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \
             > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
+          NGINX_HOST: ${{ secrets.NGINX_HOST }}
+          NGINX_USER: ${{ secrets.NGINX_USER || 'ubuntu' }}
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -515,7 +518,7 @@ jobs:
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV \
             REPOSITORY_BUCKET=$REPOSITORY_BUCKET_DEV \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
           make deploy-remote \
             GIT_BRANCH=$GIT_BRANCH \
             REMOTE_DEPLOY_BRANCH=main \
@@ -530,7 +533,7 @@ jobs:
             MMDB_TOKEN=$MMDB_TOKEN \
             NEW_RELIC_API_KEY=$NEW_RELIC_API_KEY NEW_RELIC_ACCOUNT_ID=$NEW_RELIC_ACCOUNT_ID NEW_RELIC_INGEST_KEY=$NEW_RELIC_INGEST_KEY \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -572,3 +575,4 @@ jobs:
           NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
           NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           MONITOR_BUCKET: ${{ secrets.MONITOR_BUCKET }}
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -335,7 +335,8 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          ssh-agent -a /tmp/ssh_agent.sock > /dev/null
+          export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
+          ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
           ssh-add "${HOME}/.ssh/id_rsa_matchID"
           BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
           BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"
@@ -489,7 +490,8 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          ssh-agent -a /tmp/ssh_agent.sock > /dev/null
+          export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
+          ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
           ssh-add "${HOME}/.ssh/id_rsa_matchID"
           BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
           BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -338,12 +338,43 @@ jobs:
           export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
           ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
           ssh-add "${HOME}/.ssh/id_rsa_matchID"
-          BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
-          BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"
+          sanitize_host() {
+            local value
+            value="$(printf '%s' "$1" | tr -d '\r\n[:space:]')"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#http://}"
+            value="${value#https://}"
+            value="${value#ssh://}"
+            if [[ "${value}" == *@* ]]; then value="${value##*@}"; fi
+            value="${value%%/*}"
+            if [[ "${value}" =~ ^\[[^]]+\]:[0-9]+$ ]]; then
+              value="${value#\[}"
+              value="${value%%\]:*}"
+            elif [[ "${value}" =~ ^[^:]+:[0-9]+$ ]]; then
+              value="${value%%:*}"
+            fi
+            printf '%s' "${value}"
+          }
+          sanitize_user() {
+            local value
+            value="$(printf '%s' "$1" | tr -d '\r\n[:space:]')"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#ssh://}"
+            if [[ "${value}" == *@* ]]; then value="${value%%@*}"; fi
+            printf '%s' "${value}"
+          }
+          BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
+          BASTION_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
           BASTION_SOURCE=nginx
-          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
-          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
-          if [ -z "$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')" ]; then BASTION_SOURCE=bastion; fi
+          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
+          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
+          if [ -z "$(sanitize_host "${NGINX_HOST}")" ]; then BASTION_SOURCE=bastion; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
           echo "bastion_source=${BASTION_SOURCE}"
@@ -493,10 +524,41 @@ jobs:
           export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
           ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
           ssh-add "${HOME}/.ssh/id_rsa_matchID"
-          BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
-          BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"
-          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
-          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
+          sanitize_host() {
+            local value
+            value="$(printf '%s' "$1" | tr -d '\r\n[:space:]')"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#http://}"
+            value="${value#https://}"
+            value="${value#ssh://}"
+            if [[ "${value}" == *@* ]]; then value="${value##*@}"; fi
+            value="${value%%/*}"
+            if [[ "${value}" =~ ^\[[^]]+\]:[0-9]+$ ]]; then
+              value="${value#\[}"
+              value="${value%%\]:*}"
+            elif [[ "${value}" =~ ^[^:]+:[0-9]+$ ]]; then
+              value="${value%%:*}"
+            fi
+            printf '%s' "${value}"
+          }
+          sanitize_user() {
+            local value
+            value="$(printf '%s' "$1" | tr -d '\r\n[:space:]')"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#ssh://}"
+            if [[ "${value}" == *@* ]]; then value="${value%%@*}"; fi
+            printf '%s' "${value}"
+          }
+          BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
+          BASTION_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
+          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
+          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
           printf '%s\n' \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -341,14 +341,14 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
-          cat > "${HOME}/.ssh/config" <<EOF
-          Host bastion
-            HostName ${BASTION_HOST_RESOLVED}
-            User ${BASTION_USER_RESOLVED}
-            IdentityFile ${HOME}/.ssh/id_rsa_matchID
-            IdentitiesOnly yes
-            StrictHostKeyChecking no
-          EOF
+          printf '%s\n' \
+            'Host bastion' \
+            "  HostName ${BASTION_HOST_RESOLVED}" \
+            "  User ${BASTION_USER_RESOLVED}" \
+            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
+            '  IdentitiesOnly yes' \
+            '  StrictHostKeyChecking no' \
+            > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
@@ -486,14 +486,14 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
-          cat > "${HOME}/.ssh/config" <<EOF
-          Host bastion
-            HostName ${BASTION_HOST_RESOLVED}
-            User ${BASTION_USER_RESOLVED}
-            IdentityFile ${HOME}/.ssh/id_rsa_matchID
-            IdentitiesOnly yes
-            StrictHostKeyChecking no
-          EOF
+          printf '%s\n' \
+            'Host bastion' \
+            "  HostName ${BASTION_HOST_RESOLVED}" \
+            "  User ${BASTION_USER_RESOLVED}" \
+            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
+            '  IdentitiesOnly yes' \
+            '  StrictHostKeyChecking no' \
+            > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -344,8 +344,8 @@ jobs:
           } > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
-          BASTION_HOST: ${{ secrets.BASTION_HOST }}
-          BASTION_USER: ${{ secrets.BASTION_USER }}
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Check dataprep year snapshot
         run: make -C packages/deces-dataprep clean full-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
@@ -456,8 +456,8 @@ jobs:
           } > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
-          BASTION_HOST: ${{ secrets.BASTION_HOST }}
-          BASTION_USER: ${{ secrets.BASTION_USER }}
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Deploy dev-deces.matchid.io
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -335,17 +335,7 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          {
-            printf 'Host *\n'
-            printf '  IdentityFile %s\n' "${HOME}/.ssh/id_rsa_matchID"
-            printf '  IdentitiesOnly yes\n'
-            printf 'Host * !%s\n' "${BASTION_HOST}"
-            printf '  ProxyCommand ssh -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no %s@%s nc %%h %%p\n' "${HOME}/.ssh/id_rsa_matchID" "${BASTION_USER}" "${BASTION_HOST}"
-          } > "${HOME}/.ssh/config"
-          chmod 600 "${HOME}/.ssh/config"
         env:
-          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
-          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Check dataprep year snapshot
         run: make -C packages/deces-dataprep clean full-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
@@ -361,8 +351,12 @@ jobs:
             SCW_FLAVOR="${SCW_FLAVOR}" SCW_VOLUME_SIZE="${SCW_VOLUME_SIZE}" SCW_VOLUME_TYPE="${SCW_VOLUME_TYPE}" \
             CHUNK_SIZE="${CHUNK_SIZE}" ES_THREADS="${ES_THREADS}" RECIPE_THREADS="${RECIPE_THREADS}" ES_MEM="${ES_MEM}" RECIPE_QUEUE="${RECIPE_QUEUE}" \
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${CD_GIT_BRANCH}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
-            REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${CD_GIT_BRANCH}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep
+            REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${CD_GIT_BRANCH}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
+            SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
+            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SCW_FLAVOR: PRO2-M
           SCW_VOLUME_SIZE: 20000000000
           SCW_VOLUME_TYPE: sbs_volume
@@ -447,17 +441,7 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          {
-            printf 'Host *\n'
-            printf '  IdentityFile %s\n' "${HOME}/.ssh/id_rsa_matchID"
-            printf '  IdentitiesOnly yes\n'
-            printf 'Host * !%s\n' "${BASTION_HOST}"
-            printf '  ProxyCommand ssh -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no %s@%s nc %%h %%p\n' "${HOME}/.ssh/id_rsa_matchID" "${BASTION_USER}" "${BASTION_HOST}"
-          } > "${HOME}/.ssh/config"
-          chmod 600 "${HOME}/.ssh/config"
         env:
-          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
-          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Deploy dev-deces.matchid.io
         run: |
@@ -467,7 +451,9 @@ jobs:
             DEPLOY_TARGET=dev \
             APP_DNS=$APP_DNS \
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV \
-            REPOSITORY_BUCKET=$REPOSITORY_BUCKET_DEV
+            REPOSITORY_BUCKET=$REPOSITORY_BUCKET_DEV \
+            SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
+            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
           make deploy-remote \
             GIT_BRANCH=$GIT_BRANCH \
             REMOTE_DEPLOY_BRANCH=main \
@@ -480,8 +466,12 @@ jobs:
             GOOGLE_ANALYTICS_ID=$GOOGLE_ANALYTICS_ID GOOGLE_ADSENSE_ID=$GOOGLE_ADSENSE_ID \
             LOG_BAN_IP=$LOG_BAN_IP \
             MMDB_TOKEN=$MMDB_TOKEN \
-            NEW_RELIC_API_KEY=$NEW_RELIC_API_KEY NEW_RELIC_ACCOUNT_ID=$NEW_RELIC_ACCOUNT_ID NEW_RELIC_INGEST_KEY=$NEW_RELIC_INGEST_KEY
+            NEW_RELIC_API_KEY=$NEW_RELIC_API_KEY NEW_RELIC_ACCOUNT_ID=$NEW_RELIC_ACCOUNT_ID NEW_RELIC_INGEST_KEY=$NEW_RELIC_INGEST_KEY \
+            SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
+            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           FILES_TO_PROCESS_DEV: deces-2020-m[0-1][0-9].txt.gz
           REPOSITORY_BUCKET_DEV: fichier-des-personnes-decedees-elasticsearch-dev
           GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -406,6 +406,10 @@ jobs:
             "  StrictHostKeyChecking no" \
             "  UserKnownHostsFile /dev/null" \
             > "${HOME}/.ssh/config"
+          {
+            echo "BASTION_HOST_RESOLVED=${BASTION_HOST_RESOLVED}"
+            echo "BASTION_USER_RESOLVED=${BASTION_USER_RESOLVED}"
+          } >> "${GITHUB_ENV}"
           sed -n 'l' "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
@@ -445,7 +449,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${CD_GIT_BRANCH}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${CD_GIT_BRANCH}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
+            CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -591,6 +595,10 @@ jobs:
             "  StrictHostKeyChecking no" \
             "  UserKnownHostsFile /dev/null" \
             > "${HOME}/.ssh/config"
+          {
+            echo "BASTION_HOST_RESOLVED=${BASTION_HOST_RESOLVED}"
+            echo "BASTION_USER_RESOLVED=${BASTION_USER_RESOLVED}"
+          } >> "${GITHUB_ENV}"
           chmod 600 "${HOME}/.ssh/config"
         env:
           NGINX_HOST: ${{ secrets.NGINX_HOST }}
@@ -608,7 +616,7 @@ jobs:
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV \
             REPOSITORY_BUCKET=$REPOSITORY_BUCKET_DEV \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
+            CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
           make deploy-remote \
             GIT_BRANCH=$GIT_BRANCH \
             REMOTE_DEPLOY_BRANCH=main \
@@ -623,7 +631,7 @@ jobs:
             MMDB_TOKEN=$MMDB_TOKEN \
             NEW_RELIC_API_KEY=$NEW_RELIC_API_KEY NEW_RELIC_ACCOUNT_ID=$NEW_RELIC_ACCOUNT_ID NEW_RELIC_INGEST_KEY=$NEW_RELIC_INGEST_KEY \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
+            CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -335,7 +335,17 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          {
+            printf 'Host *\n'
+            printf '  IdentityFile %s\n' "${HOME}/.ssh/id_rsa_matchID"
+            printf '  IdentitiesOnly yes\n'
+            printf 'Host * !%s\n' "${BASTION_HOST}"
+            printf '  ProxyCommand ssh -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no %s@%s nc %%h %%p\n' "${HOME}/.ssh/id_rsa_matchID" "${BASTION_USER}" "${BASTION_HOST}"
+          } > "${HOME}/.ssh/config"
+          chmod 600 "${HOME}/.ssh/config"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Check dataprep year snapshot
         run: make -C packages/deces-dataprep clean full-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
@@ -437,7 +447,17 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          {
+            printf 'Host *\n'
+            printf '  IdentityFile %s\n' "${HOME}/.ssh/id_rsa_matchID"
+            printf '  IdentitiesOnly yes\n'
+            printf 'Host * !%s\n' "${BASTION_HOST}"
+            printf '  ProxyCommand ssh -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no %s@%s nc %%h %%p\n' "${HOME}/.ssh/id_rsa_matchID" "${BASTION_USER}" "${BASTION_HOST}"
+          } > "${HOME}/.ssh/config"
+          chmod 600 "${HOME}/.ssh/config"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Deploy dev-deces.matchid.io
         run: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -335,10 +335,16 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          BASTION_HOST_RESOLVED="$(sed -n 's/^export NGINX_HOST=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          BASTION_USER_RESOLVED="$(sed -n 's/^export NGINX_USER=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
+          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
+          test -n "${BASTION_HOST_RESOLVED}"
+          test -n "${BASTION_USER_RESOLVED}"
           cat > "${HOME}/.ssh/config" <<EOF
           Host bastion
-            HostName ${BASTION_HOST}
-            User ${BASTION_USER}
+            HostName ${BASTION_HOST_RESOLVED}
+            User ${BASTION_USER_RESOLVED}
             IdentityFile ${HOME}/.ssh/id_rsa_matchID
             IdentitiesOnly yes
             StrictHostKeyChecking no
@@ -452,10 +458,16 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          BASTION_HOST_RESOLVED="$(sed -n 's/^export NGINX_HOST=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          BASTION_USER_RESOLVED="$(sed -n 's/^export NGINX_USER=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
+          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
+          test -n "${BASTION_HOST_RESOLVED}"
+          test -n "${BASTION_USER_RESOLVED}"
           cat > "${HOME}/.ssh/config" <<EOF
           Host bastion
-            HostName ${BASTION_HOST}
-            User ${BASTION_USER}
+            HostName ${BASTION_HOST_RESOLVED}
+            User ${BASTION_USER_RESOLVED}
             IdentityFile ${HOME}/.ssh/id_rsa_matchID
             IdentitiesOnly yes
             StrictHostKeyChecking no

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -467,7 +467,15 @@ jobs:
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       - name: Export dataprep year snapshot metadata
         run: |
-          make -C packages/deces-dataprep repository-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
+          rm -f packages/deces-dataprep/repository-check
+          for attempt in $(seq 1 12); do
+            make -C packages/deces-dataprep repository-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
+            if test -s packages/deces-dataprep/repository-check; then
+              break
+            fi
+            rm -f packages/deces-dataprep/repository-check
+            sleep 5
+          done
           test -s packages/deces-dataprep/repository-check
           SNAPSHOT_NAME=$(cat packages/deces-dataprep/repository-check)
           {

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -159,6 +159,10 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
+          if ! getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
+            # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
+            BASTION_HOST_RESOLVED=163.172.185.238
+          fi
           printf '%s\n' \
             "Host * !${BASTION_HOST_RESOLVED}" \
             "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -225,7 +225,15 @@ jobs:
       - name: Capture prod snapshot metadata
         run: |
           set -euo pipefail
-          make -C packages/deces-dataprep repository-check GIT_BRANCH=master REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}"
+          rm -f packages/deces-dataprep/repository-check
+          for attempt in $(seq 1 12); do
+            make -C packages/deces-dataprep repository-check GIT_BRANCH=master REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}"
+            if test -s packages/deces-dataprep/repository-check; then
+              break
+            fi
+            rm -f packages/deces-dataprep/repository-check
+            sleep 5
+          done
           test -s packages/deces-dataprep/repository-check
           SNAPSHOT_NAME=$(cat packages/deces-dataprep/repository-check)
           DATAPREP_VERSION=$(echo "${SNAPSHOT_NAME}" | sed -E 's/^esdata_([^_]+)_.*/\1/')

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -119,7 +119,18 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          cat > "${HOME}/.ssh/config" <<EOF
+          Host bastion
+            HostName ${BASTION_HOST}
+            User ${BASTION_USER}
+            IdentityFile ${HOME}/.ssh/id_rsa_matchID
+            IdentitiesOnly yes
+            StrictHostKeyChecking no
+          EOF
+          chmod 600 "${HOME}/.ssh/config"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Check dataprep full snapshot
@@ -140,7 +151,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -224,7 +235,7 @@ jobs:
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
             DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -246,7 +257,7 @@ jobs:
             MMDB_TOKEN="${MMDB_TOKEN}" \
             NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
 
       - name: Write dataprep monthly metadata artifact
         run: |

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -119,7 +119,8 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          ssh-agent -a /tmp/ssh_agent.sock > /dev/null
+          export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
+          ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
           ssh-add "${HOME}/.ssh/id_rsa_matchID"
           BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
           BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -119,22 +119,22 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          BASTION_HOST_RESOLVED="$(sed -n 's/^export NGINX_HOST=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
-          BASTION_USER_RESOLVED="$(sed -n 's/^export NGINX_USER=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          ssh-agent -a /tmp/ssh_agent.sock > /dev/null
+          ssh-add "${HOME}/.ssh/id_rsa_matchID"
+          BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
+          BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
           printf '%s\n' \
-            'Host bastion' \
-            "  HostName ${BASTION_HOST_RESOLVED}" \
-            "  User ${BASTION_USER_RESOLVED}" \
-            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
-            '  IdentitiesOnly yes' \
-            '  StrictHostKeyChecking no' \
+            "Host * !${BASTION_HOST_RESOLVED}" \
+            "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \
             > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
+          NGINX_HOST: ${{ secrets.NGINX_HOST }}
+          NGINX_USER: ${{ secrets.NGINX_USER || 'ubuntu' }}
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -157,7 +157,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -171,6 +171,7 @@ jobs:
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
 
       - name: Capture prod snapshot metadata
         run: |
@@ -230,6 +231,7 @@ jobs:
           NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
           NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           MONITOR_BUCKET: ${{ secrets.MONITOR_BUCKET }}
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           make deploy-remote-preflight \
             GIT_BRANCH=master \
@@ -241,7 +243,7 @@ jobs:
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
             DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -263,7 +265,7 @@ jobs:
             MMDB_TOKEN="${MMDB_TOKEN}" \
             NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
 
       - name: Write dataprep monthly metadata artifact
         run: |

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -128,8 +128,8 @@ jobs:
           } > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
-          BASTION_HOST: ${{ secrets.BASTION_HOST }}
-          BASTION_USER: ${{ secrets.BASTION_USER }}
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Check dataprep full snapshot

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -176,6 +176,10 @@ jobs:
             "  StrictHostKeyChecking no" \
             "  UserKnownHostsFile /dev/null" \
             > "${HOME}/.ssh/config"
+          {
+            echo "BASTION_HOST_RESOLVED=${BASTION_HOST_RESOLVED}"
+            echo "BASTION_USER_RESOLVED=${BASTION_USER_RESOLVED}"
+          } >> "${GITHUB_ENV}"
           chmod 600 "${HOME}/.ssh/config"
         env:
           NGINX_HOST: ${{ secrets.NGINX_HOST }}
@@ -202,7 +206,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
+            CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -288,7 +292,7 @@ jobs:
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
             DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
+            CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -310,7 +314,7 @@ jobs:
             MMDB_TOKEN="${MMDB_TOKEN}" \
             NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
+            CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
 
       - name: Write dataprep monthly metadata artifact
         run: |

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -164,8 +164,17 @@ jobs:
             BASTION_HOST_RESOLVED=163.172.185.238
           fi
           printf '%s\n' \
-            "Host * !${BASTION_HOST_RESOLVED}" \
-            "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \
+            "Host bastion" \
+            "  HostName ${BASTION_HOST_RESOLVED}" \
+            "  User ${BASTION_USER_RESOLVED}" \
+            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
+            "  IdentitiesOnly yes" \
+            "  StrictHostKeyChecking no" \
+            "  UserKnownHostsFile /dev/null" \
+            "Host * !bastion" \
+            "  ProxyJump bastion" \
+            "  StrictHostKeyChecking no" \
+            "  UserKnownHostsFile /dev/null" \
             > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -119,7 +119,17 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          {
+            printf 'Host *\n'
+            printf '  IdentityFile %s\n' "${HOME}/.ssh/id_rsa_matchID"
+            printf '  IdentitiesOnly yes\n'
+            printf 'Host * !%s\n' "${BASTION_HOST}"
+            printf '  ProxyCommand ssh -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no %s@%s nc %%h %%p\n' "${HOME}/.ssh/id_rsa_matchID" "${BASTION_USER}" "${BASTION_HOST}"
+          } > "${HOME}/.ssh/config"
+          chmod 600 "${HOME}/.ssh/config"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Check dataprep full snapshot

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -119,10 +119,16 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          BASTION_HOST_RESOLVED="$(sed -n 's/^export NGINX_HOST=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          BASTION_USER_RESOLVED="$(sed -n 's/^export NGINX_USER=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
+          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
+          test -n "${BASTION_HOST_RESOLVED}"
+          test -n "${BASTION_USER_RESOLVED}"
           cat > "${HOME}/.ssh/config" <<EOF
           Host bastion
-            HostName ${BASTION_HOST}
-            User ${BASTION_USER}
+            HostName ${BASTION_HOST_RESOLVED}
+            User ${BASTION_USER_RESOLVED}
             IdentityFile ${HOME}/.ssh/id_rsa_matchID
             IdentitiesOnly yes
             StrictHostKeyChecking no

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -154,7 +154,7 @@ jobs:
             printf '%s' "${value}"
           }
           BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
-          BASTION_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
+          BASTION_USER_RESOLVED=ubuntu
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           test -n "${BASTION_HOST_RESOLVED}"

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -125,14 +125,14 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
-          cat > "${HOME}/.ssh/config" <<EOF
-          Host bastion
-            HostName ${BASTION_HOST_RESOLVED}
-            User ${BASTION_USER_RESOLVED}
-            IdentityFile ${HOME}/.ssh/id_rsa_matchID
-            IdentitiesOnly yes
-            StrictHostKeyChecking no
-          EOF
+          printf '%s\n' \
+            'Host bastion' \
+            "  HostName ${BASTION_HOST_RESOLVED}" \
+            "  User ${BASTION_USER_RESOLVED}" \
+            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
+            '  IdentitiesOnly yes' \
+            '  StrictHostKeyChecking no' \
+            > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -157,7 +157,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -241,7 +241,7 @@ jobs:
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
             DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -263,7 +263,7 @@ jobs:
             MMDB_TOKEN="${MMDB_TOKEN}" \
             NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
 
       - name: Write dataprep monthly metadata artifact
         run: |

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -122,10 +122,41 @@ jobs:
           export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
           ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
           ssh-add "${HOME}/.ssh/id_rsa_matchID"
-          BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
-          BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"
-          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
-          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
+          sanitize_host() {
+            local value
+            value="$(printf '%s' "$1" | tr -d '\r\n[:space:]')"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#http://}"
+            value="${value#https://}"
+            value="${value#ssh://}"
+            if [[ "${value}" == *@* ]]; then value="${value##*@}"; fi
+            value="${value%%/*}"
+            if [[ "${value}" =~ ^\[[^]]+\]:[0-9]+$ ]]; then
+              value="${value#\[}"
+              value="${value%%\]:*}"
+            elif [[ "${value}" =~ ^[^:]+:[0-9]+$ ]]; then
+              value="${value%%:*}"
+            fi
+            printf '%s' "${value}"
+          }
+          sanitize_user() {
+            local value
+            value="$(printf '%s' "$1" | tr -d '\r\n[:space:]')"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#ssh://}"
+            if [[ "${value}" == *@* ]]; then value="${value%%@*}"; fi
+            printf '%s' "${value}"
+          }
+          BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
+          BASTION_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
+          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
+          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
           printf '%s\n' \

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -119,17 +119,7 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          {
-            printf 'Host *\n'
-            printf '  IdentityFile %s\n' "${HOME}/.ssh/id_rsa_matchID"
-            printf '  IdentitiesOnly yes\n'
-            printf 'Host * !%s\n' "${BASTION_HOST}"
-            printf '  ProxyCommand ssh -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no %s@%s nc %%h %%p\n' "${HOME}/.ssh/id_rsa_matchID" "${BASTION_USER}" "${BASTION_HOST}"
-          } > "${HOME}/.ssh/config"
-          chmod 600 "${HOME}/.ssh/config"
         env:
-          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
-          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Check dataprep full snapshot
@@ -148,8 +138,12 @@ jobs:
             CHUNK_SIZE="${DATAPREP_CHUNK_SIZE_PROD}" ES_THREADS="${DATAPREP_ES_THREADS_PROD}" RECIPE_THREADS="${DATAPREP_RECIPE_THREADS_PROD}" ES_MEM="${DATAPREP_ES_MEM_PROD}" RECIPE_QUEUE="${DATAPREP_RECIPE_QUEUE_PROD}" \
             SLACK_TITLE="deces-dataprep - monthly" SLACK_WEBHOOK="${SLACK_WEBHOOK}" \
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
-            REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep
+            REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
+            SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
+            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           PROD_TAG: ${{ steps.context.outputs.prod_tag }}
           remote_http_proxy: ${{ secrets.remote_http_proxy }}
           remote_https_proxy: ${{ secrets.remote_https_proxy }}
@@ -180,6 +174,8 @@ jobs:
 
       - name: Deploy deces.matchid.io
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           PROD_TAG: ${{ steps.context.outputs.prod_tag }}
           GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
           GOOGLE_ADSENSE_ID: ${{ secrets.GOOGLE_ADSENSE_ID }}
@@ -226,7 +222,9 @@ jobs:
             APP_DNS="${APP_DNS}" \
             REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}" \
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
-            DATA_VERSION_OVERRIDE="${DATA_VERSION}"
+            DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
+            SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
+            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -246,7 +244,9 @@ jobs:
             GOOGLE_ANALYTICS_ID="${GOOGLE_ANALYTICS_ID}" GOOGLE_ADSENSE_ID="${GOOGLE_ADSENSE_ID}" \
             LOG_BAN_IP="${LOG_BAN_IP}" \
             MMDB_TOKEN="${MMDB_TOKEN}" \
-            NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}"
+            NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
+            SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
+            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
 
       - name: Write dataprep monthly metadata artifact
         run: |

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -200,17 +200,7 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          {
-            printf 'Host *\n'
-            printf '  IdentityFile %s\n' "${HOME}/.ssh/id_rsa_matchID"
-            printf '  IdentitiesOnly yes\n'
-            printf 'Host * !%s\n' "${BASTION_HOST}"
-            printf '  ProxyCommand ssh -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no %s@%s nc %%h %%p\n' "${HOME}/.ssh/id_rsa_matchID" "${BASTION_USER}" "${BASTION_HOST}"
-          } > "${HOME}/.ssh/config"
-          chmod 600 "${HOME}/.ssh/config"
         env:
-          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
-          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Check dataprep full snapshot
@@ -231,8 +221,12 @@ jobs:
             CHUNK_SIZE="${DATAPREP_CHUNK_SIZE_PROD}" ES_THREADS="${DATAPREP_ES_THREADS_PROD}" RECIPE_THREADS="${DATAPREP_RECIPE_THREADS_PROD}" ES_MEM="${DATAPREP_ES_MEM_PROD}" RECIPE_QUEUE="${DATAPREP_RECIPE_QUEUE_PROD}" \
             SLACK_TITLE="deces-dataprep - full" SLACK_WEBHOOK="${SLACK_WEBHOOK}" \
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
-            REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep
+            REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
+            SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
+            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           PROD_TAG: ${{ steps.context.outputs.prod_tag }}
           remote_http_proxy: ${{ secrets.remote_http_proxy }}
           remote_https_proxy: ${{ secrets.remote_https_proxy }}
@@ -277,6 +271,8 @@ jobs:
 
       - name: Deploy deces.matchid.io
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           PROD_TAG: ${{ steps.context.outputs.prod_tag }}
           GOOGLE_ANALYTICS_ID: ${{ secrets.GOOGLE_ANALYTICS_ID }}
           GOOGLE_ADSENSE_ID: ${{ secrets.GOOGLE_ADSENSE_ID }}
@@ -323,7 +319,9 @@ jobs:
             APP_DNS="${APP_DNS}" \
             REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}" \
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
-            DATA_VERSION_OVERRIDE="${DATA_VERSION}"
+            DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
+            SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
+            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -343,7 +341,9 @@ jobs:
             GOOGLE_ANALYTICS_ID="${GOOGLE_ANALYTICS_ID}" GOOGLE_ADSENSE_ID="${GOOGLE_ADSENSE_ID}" \
             LOG_BAN_IP="${LOG_BAN_IP}" \
             MMDB_TOKEN="${MMDB_TOKEN}" \
-            NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}"
+            NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
+            SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
+            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
 
       - name: Write release metadata artifact
         run: |

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -200,7 +200,17 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          {
+            printf 'Host *\n'
+            printf '  IdentityFile %s\n' "${HOME}/.ssh/id_rsa_matchID"
+            printf '  IdentitiesOnly yes\n'
+            printf 'Host * !%s\n' "${BASTION_HOST}"
+            printf '  ProxyCommand ssh -i %s -o IdentitiesOnly=yes -o StrictHostKeyChecking=no %s@%s nc %%h %%p\n' "${HOME}/.ssh/id_rsa_matchID" "${BASTION_USER}" "${BASTION_HOST}"
+          } > "${HOME}/.ssh/config"
+          chmod 600 "${HOME}/.ssh/config"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Check dataprep full snapshot

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -200,7 +200,18 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          cat > "${HOME}/.ssh/config" <<EOF
+          Host bastion
+            HostName ${BASTION_HOST}
+            User ${BASTION_USER}
+            IdentityFile ${HOME}/.ssh/id_rsa_matchID
+            IdentitiesOnly yes
+            StrictHostKeyChecking no
+          EOF
+          chmod 600 "${HOME}/.ssh/config"
         env:
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Check dataprep full snapshot
@@ -223,7 +234,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -321,7 +332,7 @@ jobs:
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
             DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -343,7 +354,7 @@ jobs:
             MMDB_TOKEN="${MMDB_TOKEN}" \
             NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J ${BASTION_USER}@${BASTION_HOST} -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
 
       - name: Write release metadata artifact
         run: |

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -203,10 +203,41 @@ jobs:
           export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
           ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
           ssh-add "${HOME}/.ssh/id_rsa_matchID"
-          BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
-          BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"
-          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
-          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
+          sanitize_host() {
+            local value
+            value="$(printf '%s' "$1" | tr -d '\r\n[:space:]')"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#http://}"
+            value="${value#https://}"
+            value="${value#ssh://}"
+            if [[ "${value}" == *@* ]]; then value="${value##*@}"; fi
+            value="${value%%/*}"
+            if [[ "${value}" =~ ^\[[^]]+\]:[0-9]+$ ]]; then
+              value="${value#\[}"
+              value="${value%%\]:*}"
+            elif [[ "${value}" =~ ^[^:]+:[0-9]+$ ]]; then
+              value="${value%%:*}"
+            fi
+            printf '%s' "${value}"
+          }
+          sanitize_user() {
+            local value
+            value="$(printf '%s' "$1" | tr -d '\r\n[:space:]')"
+            value="${value#\"}"
+            value="${value%\"}"
+            value="${value#\'}"
+            value="${value%\'}"
+            value="${value#ssh://}"
+            if [[ "${value}" == *@* ]]; then value="${value%%@*}"; fi
+            printf '%s' "${value}"
+          }
+          BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
+          BASTION_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
+          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
+          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
           printf '%s\n' \

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -200,10 +200,16 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          BASTION_HOST_RESOLVED="$(sed -n 's/^export NGINX_HOST=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          BASTION_USER_RESOLVED="$(sed -n 's/^export NGINX_USER=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
+          if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
+          test -n "${BASTION_HOST_RESOLVED}"
+          test -n "${BASTION_USER_RESOLVED}"
           cat > "${HOME}/.ssh/config" <<EOF
           Host bastion
-            HostName ${BASTION_HOST}
-            User ${BASTION_USER}
+            HostName ${BASTION_HOST_RESOLVED}
+            User ${BASTION_USER_RESOLVED}
             IdentityFile ${HOME}/.ssh/id_rsa_matchID
             IdentitiesOnly yes
             StrictHostKeyChecking no

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -200,7 +200,8 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          ssh-agent -a /tmp/ssh_agent.sock > /dev/null
+          export SSH_AUTH_SOCK=/tmp/ssh_agent.sock
+          ssh-agent -a "${SSH_AUTH_SOCK}" > /dev/null
           ssh-add "${HOME}/.ssh/id_rsa_matchID"
           BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
           BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -235,7 +235,7 @@ jobs:
             printf '%s' "${value}"
           }
           BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
-          BASTION_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
+          BASTION_USER_RESOLVED=ubuntu
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           test -n "${BASTION_HOST_RESOLVED}"

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -257,6 +257,10 @@ jobs:
             "  StrictHostKeyChecking no" \
             "  UserKnownHostsFile /dev/null" \
             > "${HOME}/.ssh/config"
+          {
+            echo "BASTION_HOST_RESOLVED=${BASTION_HOST_RESOLVED}"
+            echo "BASTION_USER_RESOLVED=${BASTION_USER_RESOLVED}"
+          } >> "${GITHUB_ENV}"
           chmod 600 "${HOME}/.ssh/config"
         env:
           NGINX_HOST: ${{ secrets.NGINX_HOST }}
@@ -285,7 +289,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
+            CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -385,7 +389,7 @@ jobs:
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
             DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
+            CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -407,7 +411,7 @@ jobs:
             MMDB_TOKEN="${MMDB_TOKEN}" \
             NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
+            CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
 
       - name: Write release metadata artifact
         run: |

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -240,6 +240,10 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
+          if ! getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
+            # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
+            BASTION_HOST_RESOLVED=163.172.185.238
+          fi
           printf '%s\n' \
             "Host * !${BASTION_HOST_RESOLVED}" \
             "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -309,7 +309,15 @@ jobs:
         if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
         run: |
           set -euo pipefail
-          make -C packages/deces-dataprep repository-check GIT_BRANCH=master REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}"
+          rm -f packages/deces-dataprep/repository-check
+          for attempt in $(seq 1 12); do
+            make -C packages/deces-dataprep repository-check GIT_BRANCH=master REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}"
+            if test -s packages/deces-dataprep/repository-check; then
+              break
+            fi
+            rm -f packages/deces-dataprep/repository-check
+            sleep 5
+          done
           test -s packages/deces-dataprep/repository-check
           SNAPSHOT_NAME=$(cat packages/deces-dataprep/repository-check)
           DATAPREP_VERSION=$(echo "${SNAPSHOT_NAME}" | sed -E 's/^esdata_([^_]+)_.*/\1/')

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -200,22 +200,22 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
-          BASTION_HOST_RESOLVED="$(sed -n 's/^export NGINX_HOST=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
-          BASTION_USER_RESOLVED="$(sed -n 's/^export NGINX_USER=//p' packages/tools/artifacts | tail -n1 | tr -d '\r\n[:space:]')"
+          ssh-agent -a /tmp/ssh_agent.sock > /dev/null
+          ssh-add "${HOME}/.ssh/id_rsa_matchID"
+          BASTION_HOST_RESOLVED="$(printf '%s' "${NGINX_HOST}" | tr -d '\r\n[:space:]')"
+          BASTION_USER_RESOLVED="$(printf '%s' "${NGINX_USER}" | tr -d '\r\n[:space:]')"
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(printf '%s' "${BASTION_HOST}" | tr -d '\r\n[:space:]')"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
           printf '%s\n' \
-            'Host bastion' \
-            "  HostName ${BASTION_HOST_RESOLVED}" \
-            "  User ${BASTION_USER_RESOLVED}" \
-            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
-            '  IdentitiesOnly yes' \
-            '  StrictHostKeyChecking no' \
+            "Host * !${BASTION_HOST_RESOLVED}" \
+            "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \
             > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
+          NGINX_HOST: ${{ secrets.NGINX_HOST }}
+          NGINX_USER: ${{ secrets.NGINX_USER || 'ubuntu' }}
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
@@ -240,7 +240,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -253,6 +253,7 @@ jobs:
           SCW_SERVER_OPTS: ${{ secrets.SCW_SERVER_OPTS }}
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Capture prod snapshot metadata
@@ -327,6 +328,7 @@ jobs:
           NEW_RELIC_API_KEY: ${{ secrets.NEW_RELIC_API_KEY }}
           NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           MONITOR_BUCKET: ${{ secrets.MONITOR_BUCKET }}
+          SSH_AUTH_SOCK: /tmp/ssh_agent.sock
         run: |
           make deploy-remote-preflight \
             GIT_BRANCH=master \
@@ -338,7 +340,7 @@ jobs:
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
             DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -360,7 +362,7 @@ jobs:
             MMDB_TOKEN="${MMDB_TOKEN}" \
             NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config"
 
       - name: Write release metadata artifact
         run: |

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -245,8 +245,17 @@ jobs:
             BASTION_HOST_RESOLVED=163.172.185.238
           fi
           printf '%s\n' \
-            "Host * !${BASTION_HOST_RESOLVED}" \
-            "  ProxyCommand ssh -F /dev/null -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ${HOME}/.ssh/id_rsa_matchID ${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED} nc %h %p" \
+            "Host bastion" \
+            "  HostName ${BASTION_HOST_RESOLVED}" \
+            "  User ${BASTION_USER_RESOLVED}" \
+            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
+            "  IdentitiesOnly yes" \
+            "  StrictHostKeyChecking no" \
+            "  UserKnownHostsFile /dev/null" \
+            "Host * !bastion" \
+            "  ProxyJump bastion" \
+            "  StrictHostKeyChecking no" \
+            "  UserKnownHostsFile /dev/null" \
             > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -240,7 +240,7 @@ jobs:
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
@@ -338,7 +338,7 @@ jobs:
             DATAPREP_VERSION_OVERRIDE="${DATAPREP_VERSION}" \
             DATA_VERSION_OVERRIDE="${DATA_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
           make deploy-remote \
             GIT_BRANCH=master \
             GIT_BACKEND_BRANCH=master \
@@ -360,7 +360,7 @@ jobs:
             MMDB_TOKEN="${MMDB_TOKEN}" \
             NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" NEW_RELIC_INGEST_KEY="${NEW_RELIC_INGEST_KEY}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
-            CLOUD_SSHOPTS="-J bastion -o IdentitiesOnly=yes"
+            CLOUD_SSHOPTS="-F ${HOME}/.ssh/config -J bastion -o IdentitiesOnly=yes"
 
       - name: Write release metadata artifact
         run: |

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -206,14 +206,14 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(printf '%s' "${BASTION_USER}" | tr -d '\r\n[:space:]')"; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
-          cat > "${HOME}/.ssh/config" <<EOF
-          Host bastion
-            HostName ${BASTION_HOST_RESOLVED}
-            User ${BASTION_USER_RESOLVED}
-            IdentityFile ${HOME}/.ssh/id_rsa_matchID
-            IdentitiesOnly yes
-            StrictHostKeyChecking no
-          EOF
+          printf '%s\n' \
+            'Host bastion' \
+            "  HostName ${BASTION_HOST_RESOLVED}" \
+            "  User ${BASTION_USER_RESOLVED}" \
+            "  IdentityFile ${HOME}/.ssh/id_rsa_matchID" \
+            '  IdentitiesOnly yes' \
+            '  StrictHostKeyChecking no' \
+            > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -209,8 +209,8 @@ jobs:
           } > "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
         env:
-          BASTION_HOST: ${{ secrets.BASTION_HOST }}
-          BASTION_USER: ${{ secrets.BASTION_USER }}
+          BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
+          BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Check dataprep full snapshot

--- a/packages/deces-dataprep/Makefile
+++ b/packages/deces-dataprep/Makefile
@@ -119,14 +119,14 @@ monorepo-elasticsearch:
 	@if [ -d "${MONOREPO_ROOT}/packages/deces-infra" ]; then\
 		${MAKE} -C ${MONOREPO_ROOT} elasticsearch-local ES_NODES=${ES_NODES} ES_MEM=${ES_MEM} ${MAKEOVERRIDES};\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch ES_NODES=${ES_NODES} ES_MEM=${ES_MEM} ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch APP=backend ES_NODES=${ES_NODES} ES_MEM=${ES_MEM} ${MAKEOVERRIDES};\
 	fi
 
 monorepo-elasticsearch-stop:
 	@if [ -d "${MONOREPO_ROOT}/packages/deces-infra" ]; then\
 		${MAKE} -C ${MONOREPO_ROOT} elasticsearch-stop ${MAKEOVERRIDES};\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-stop ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-stop APP=backend ${MAKEOVERRIDES};\
 	fi
 
 frontend-config: dataprep-frontend-check
@@ -176,7 +176,7 @@ repository-config: config
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			${MAKEOVERRIDES};\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-config\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-config APP=backend\
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			${MAKEOVERRIDES};\
 	fi && touch repository-config
@@ -188,7 +188,7 @@ ${REPOSITORY_CHECK}: repository-config data-tag
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			${MAKEOVERRIDES} | egrep -qx "$${ES_BACKUP_NAME}";\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-check\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-check APP=backend\
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			${MAKEOVERRIDES} ES_BACKUP_NAME=$${ES_BACKUP_NAME} \
 			| egrep -q "^snapshot found";\
@@ -211,25 +211,26 @@ backup-pull: data-tag
 	touch backup-pull
 
 dev: config monorepo-elasticsearch frontend-config
-	@${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} ${MAKEOVERRIDES} &&\
+	@${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} APP=backend ${MAKEOVERRIDES} &&\
 	${MAKE} -C ${FRONTEND_PATH} frontend-dev GIT_BRANCH=${GIT_FRONTEND_BRANCH} NPM_AUDIT_IGNORE=true ${MAKEOVERRIDES} &&\
 		echo matchID started, go to http://localhost:8081
 
 dev-stop:
 	@if [ -f config ]; then\
 		if [ -d "${FRONTEND_PATH}" ]; then ${MAKE} -C ${FRONTEND_PATH} frontend-dev-stop ${MAKEOVERRIDES}; fi;\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} APP=backend ${MAKEOVERRIDES};\
 		${MAKE} monorepo-elasticsearch-stop ${MAKEOVERRIDES};\
 	fi
 
 up:
 	@unset APP;unset APP_VERSION;\
 	${MAKE} monorepo-elasticsearch ${MAKEOVERRIDES};\
-	${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_DEPLOY_TARGET} ${MAKEOVERRIDES} && echo matchID backend services started
+	${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_DEPLOY_TARGET} APP=backend ${MAKEOVERRIDES} && echo matchID backend services started
 
 dataprep-backend-recipe-run:
 	@if grep -q 'BACKEND_RUN_TARGET ?=' ${DATAPREP_BACKEND_PATH}/Makefile; then\
 		${MAKE} -C ${DATAPREP_BACKEND_PATH} recipe-run \
+			APP=backend \
 			ES_HOST=${ES_HOST} \
 			BACKEND_RUN_TARGET=${DATAPREP_BACKEND_LOCAL_TARGET} \
 			BACKEND_RUN_CONTAINER=${DATAPREP_BACKEND_RUN_CONTAINER} \
@@ -238,7 +239,7 @@ dataprep-backend-recipe-run:
 			STORAGE_BUCKET=${STORAGE_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			${MAKEOVERRIDES};\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} ES_HOST=${ES_HOST} ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} APP=backend ES_HOST=${ES_HOST} ${MAKEOVERRIDES};\
 		BACKEND_CONTAINER="${DATAPREP_BACKEND_RUN_CONTAINER}";\
 		if [ -z "$$BACKEND_CONTAINER" ]; then\
 			if [ "${DATAPREP_BACKEND_LOCAL_TARGET}" = "backend-dev" ]; then\
@@ -275,7 +276,7 @@ recipe-run-local: data-tag
 	@if [ ! -f "${RECIPE_RUN_MARKER}" ];then\
 		mkdir -p $$(dirname "${RECIPE_RUN_MARKER}") $$(dirname "${S3_PULL_MARKER}");\
 		echo running recipe on data FILES_TO_PROCESS="${FILES_TO_PROCESS}" $$(cat ${DATA_TAG}), dataprep ${DATAPREP_VERSION};\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} version;\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} version APP=backend;\
 		${MAKE} dataprep-backend-recipe-run ${MAKEOVERRIDES} \
 			&&\
 		touch "${RECIPE_RUN_MARKER}" "${S3_PULL_MARKER}" &&\
@@ -327,7 +328,7 @@ watch-run:
 
 backup-restore: backup-pull
 	@if [ ! -f "elasticsearch-restore" ];then\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-restore ES_BACKUP_FILE=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).tar \
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-restore APP=backend ES_BACKUP_FILE=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).tar \
 			&& (echo esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).tar > elasticsearch-restore);\
 	fi
 
@@ -339,7 +340,7 @@ repository-restore: repository-check
 				REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
 		else\
-			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-restore\
+			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-restore APP=backend\
 				REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
 		fi && (echo $${ES_BACKUP_NAME} > elasticsearch-restore);\
@@ -355,7 +356,7 @@ backup: data-tag
 		ES_BACKUP_FILE=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).tar;\
 		ES_BACKUP_FILE_SNAR=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).snar;\
 		if [ ! -f "${BACKUP_DIR}/$$ES_BACKUP_FILE" ];then\
-			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-backup \
+			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-backup APP=backend \
 				ES_BACKUP_FILE=$$ES_BACKUP_FILE\
 				ES_BACKUP_FILE_SNAR=$$ES_BACKUP_FILE_SNAR;\
 		fi;\
@@ -365,7 +366,7 @@ backup: data-tag
 backup-push: data-tag backup
 	@if [ ! -f backup-push ];then\
 		ES_BACKUP_FILE_ROOT=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG});\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-storage-push\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-storage-push APP=backend\
 			STORAGE_BUCKET=${STORAGE_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			ES_BACKUP_FILE=$$ES_BACKUP_FILE_ROOT.tar\
 			ES_BACKUP_FILE_SNAR=$$ES_BACKUP_FILE_ROOT.snar &&\
@@ -382,7 +383,7 @@ repository-push: data-tag
 				REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
 		else\
-			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-backup\
+			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-backup APP=backend\
 				REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
 		fi && touch repository-push;\
@@ -395,7 +396,7 @@ repository-backup-tmp: data-tag
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-backup-async\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-backup-async APP=backend\
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
 	fi
@@ -407,7 +408,7 @@ respository-cleanse:
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} > /dev/null 2>&1;\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-delete\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-delete APP=backend\
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} > /dev/null 2>&1;\
 	fi) || exit 0
@@ -415,7 +416,7 @@ respository-cleanse:
 down:
 	@if [ -f config ]; then\
 		if [ -d "${FRONTEND_PATH}" ]; then ${MAKE} -C ${FRONTEND_PATH} frontend-dev-stop ${MAKEOVERRIDES}; fi;\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} APP=backend ${MAKEOVERRIDES};\
 		${MAKE} monorepo-elasticsearch-stop ${MAKEOVERRIDES};\
 	fi
 

--- a/packages/deces-dataprep/Makefile
+++ b/packages/deces-dataprep/Makefile
@@ -78,6 +78,7 @@ export SCW_VOLUME_SIZE=50000000000
 export SCW_IMAGE_ID=8e7f9833-9787-4488-aea7-819183132acc
 export MONOREPO_TOOLS_PATH=${APP_PATH}/../tools
 export MONOREPO_ROOT=${APP_PATH}/../..
+DATAPREP_BACKEND_MAKEOVERRIDES := $(filter-out APP=%,$(MAKEOVERRIDES))
 export INFRA_PATH=${MONOREPO_ROOT}/packages/deces-infra
 export FRONTEND_PATH=${DATAPREP_FRONTEND_PATH}
 
@@ -119,14 +120,14 @@ monorepo-elasticsearch:
 	@if [ -d "${MONOREPO_ROOT}/packages/deces-infra" ]; then\
 		${MAKE} -C ${MONOREPO_ROOT} elasticsearch-local ES_NODES=${ES_NODES} ES_MEM=${ES_MEM} ${MAKEOVERRIDES};\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch APP=backend ES_NODES=${ES_NODES} ES_MEM=${ES_MEM} ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch ES_NODES=${ES_NODES} ES_MEM=${ES_MEM} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 	fi
 
 monorepo-elasticsearch-stop:
 	@if [ -d "${MONOREPO_ROOT}/packages/deces-infra" ]; then\
 		${MAKE} -C ${MONOREPO_ROOT} elasticsearch-stop ${MAKEOVERRIDES};\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-stop APP=backend ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-stop ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 	fi
 
 frontend-config: dataprep-frontend-check
@@ -176,9 +177,9 @@ repository-config: config
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			${MAKEOVERRIDES};\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-config APP=backend\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-config\
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
-			${MAKEOVERRIDES};\
+			${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 	fi && touch repository-config
 
 ${REPOSITORY_CHECK}: repository-config data-tag
@@ -188,9 +189,9 @@ ${REPOSITORY_CHECK}: repository-config data-tag
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			${MAKEOVERRIDES} | egrep -qx "$${ES_BACKUP_NAME}";\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-check APP=backend\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-check\
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
-			${MAKEOVERRIDES} ES_BACKUP_NAME=$${ES_BACKUP_NAME} \
+			${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend ES_BACKUP_NAME=$${ES_BACKUP_NAME} \
 			| egrep -q "^snapshot found";\
 	fi\
 		&& echo "snapshot found for or $${ES_BACKUP_NAME} in elasticsearch repository" && (echo "$${ES_BACKUP_NAME}" > "${REPOSITORY_CHECK}") \
@@ -211,35 +212,34 @@ backup-pull: data-tag
 	touch backup-pull
 
 dev: config monorepo-elasticsearch frontend-config
-	@${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} APP=backend ${MAKEOVERRIDES} &&\
+	@${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend &&\
 	${MAKE} -C ${FRONTEND_PATH} frontend-dev GIT_BRANCH=${GIT_FRONTEND_BRANCH} NPM_AUDIT_IGNORE=true ${MAKEOVERRIDES} &&\
 		echo matchID started, go to http://localhost:8081
 
 dev-stop:
 	@if [ -f config ]; then\
 		if [ -d "${FRONTEND_PATH}" ]; then ${MAKE} -C ${FRONTEND_PATH} frontend-dev-stop ${MAKEOVERRIDES}; fi;\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} APP=backend ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 		${MAKE} monorepo-elasticsearch-stop ${MAKEOVERRIDES};\
 	fi
 
 up:
 	@unset APP;unset APP_VERSION;\
 	${MAKE} monorepo-elasticsearch ${MAKEOVERRIDES};\
-	${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_DEPLOY_TARGET} APP=backend ${MAKEOVERRIDES} && echo matchID backend services started
+	${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_DEPLOY_TARGET} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend && echo matchID backend services started
 
 dataprep-backend-recipe-run:
 	@if grep -q 'BACKEND_RUN_TARGET ?=' ${DATAPREP_BACKEND_PATH}/Makefile; then\
 		${MAKE} -C ${DATAPREP_BACKEND_PATH} recipe-run \
-			APP=backend \
 			ES_HOST=${ES_HOST} \
 			BACKEND_RUN_TARGET=${DATAPREP_BACKEND_LOCAL_TARGET} \
 			BACKEND_RUN_CONTAINER=${DATAPREP_BACKEND_RUN_CONTAINER} \
 			CHUNK_SIZE=${CHUNK_SIZE} RECIPE=${RECIPE} RECIPE_THREADS=${RECIPE_THREADS} RECIPE_QUEUE=${RECIPE_QUEUE} \
 			ES_PRELOAD='${ES_PRELOAD}' ES_THREADS=${ES_THREADS} \
 			STORAGE_BUCKET=${STORAGE_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
-			${MAKEOVERRIDES};\
+			${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} APP=backend ES_HOST=${ES_HOST} ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} ES_HOST=${ES_HOST} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 		BACKEND_CONTAINER="${DATAPREP_BACKEND_RUN_CONTAINER}";\
 		if [ -z "$$BACKEND_CONTAINER" ]; then\
 			if [ "${DATAPREP_BACKEND_LOCAL_TARGET}" = "backend-dev" ]; then\
@@ -328,7 +328,8 @@ watch-run:
 
 backup-restore: backup-pull
 	@if [ ! -f "elasticsearch-restore" ];then\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-restore APP=backend ES_BACKUP_FILE=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).tar \
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-restore ES_BACKUP_FILE=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).tar \
+			${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend \
 			&& (echo esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).tar > elasticsearch-restore);\
 	fi
 
@@ -340,9 +341,9 @@ repository-restore: repository-check
 				REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
 		else\
-			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-restore APP=backend\
+			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-restore\
 				REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
-				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
+				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 		fi && (echo $${ES_BACKUP_NAME} > elasticsearch-restore);\
 	fi
 
@@ -356,9 +357,9 @@ backup: data-tag
 		ES_BACKUP_FILE=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).tar;\
 		ES_BACKUP_FILE_SNAR=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG}).snar;\
 		if [ ! -f "${BACKUP_DIR}/$$ES_BACKUP_FILE" ];then\
-			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-backup APP=backend \
+			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-backup \
 				ES_BACKUP_FILE=$$ES_BACKUP_FILE\
-				ES_BACKUP_FILE_SNAR=$$ES_BACKUP_FILE_SNAR;\
+				ES_BACKUP_FILE_SNAR=$$ES_BACKUP_FILE_SNAR ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 		fi;\
 		touch backup;\
 	fi
@@ -366,10 +367,10 @@ backup: data-tag
 backup-push: data-tag backup
 	@if [ ! -f backup-push ];then\
 		ES_BACKUP_FILE_ROOT=esdata_${DATAPREP_VERSION}_$$(cat ${DATA_TAG});\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-storage-push APP=backend\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-storage-push\
 			STORAGE_BUCKET=${STORAGE_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			ES_BACKUP_FILE=$$ES_BACKUP_FILE_ROOT.tar\
-			ES_BACKUP_FILE_SNAR=$$ES_BACKUP_FILE_ROOT.snar &&\
+			ES_BACKUP_FILE_SNAR=$$ES_BACKUP_FILE_ROOT.snar ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend &&\
 			touch backup-push &&\
 			SIZE=`cd ${BACKUP_DIR}; du -sh $$ES_BACKUP_FILE_ROOT.tar`;\
 			echo pushed $$SIZE to storage ${DATAGOUV_DATASET};\
@@ -383,9 +384,9 @@ repository-push: data-tag
 				REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
 		else\
-			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-backup APP=backend\
+			${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-backup\
 				REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
-				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
+				ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 		fi && touch repository-push;\
 		fi
 
@@ -396,9 +397,9 @@ repository-backup-tmp: data-tag
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-backup-async APP=backend\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-backup-async\
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
-			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${MAKEOVERRIDES};\
+			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 	fi
 
 respository-cleanse:
@@ -408,15 +409,15 @@ respository-cleanse:
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
 			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} > /dev/null 2>&1;\
 	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-delete APP=backend\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} elasticsearch-repository-delete\
 			REPOSITORY_BUCKET=${REPOSITORY_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
-			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} > /dev/null 2>&1;\
+			ES_INDEX=${ES_INDEX} ES_BACKUP_NAME=$${ES_BACKUP_NAME} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend > /dev/null 2>&1;\
 	fi) || exit 0
 
 down:
 	@if [ -f config ]; then\
 		if [ -d "${FRONTEND_PATH}" ]; then ${MAKE} -C ${FRONTEND_PATH} frontend-dev-stop ${MAKEOVERRIDES}; fi;\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} APP=backend ${MAKEOVERRIDES};\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 		${MAKE} monorepo-elasticsearch-stop ${MAKEOVERRIDES};\
 	fi
 

--- a/packages/deces-dataprep/Makefile
+++ b/packages/deces-dataprep/Makefile
@@ -292,7 +292,7 @@ full-check: datagouv-to-${DATAGOUV_CONNECTOR} check-${DATAGOUV_CONNECTOR}
 	fi
 
 full: full-check recipe-run
-	@echo Total records in index: `docker exec -it matchid-elasticsearch curl localhost:9200/_cat/indices | awk '{printf $$7}'`
+	@echo Total records in index: `docker exec -i ${ES_HOST} curl localhost:9200/_cat/indices | awk '{printf $$7}'`
 	@touch full
 
 

--- a/packages/deces-dataprep/Makefile
+++ b/packages/deces-dataprep/Makefile
@@ -70,7 +70,7 @@ EC2=ec2 ${EC2_ENDPOINT_OPTION} --profile ${EC2_PROFILE}
 EC2_SERVER_FILE_ID=${PWD}/ec2.id
 EC2_TIMEOUT= 120
 CLOUD=SCW
-SSHOPTS=-o "StrictHostKeyChecking no" -i ${SSHKEY} ${CLOUD_SSHOPTS}
+SSHOPTS=-o StrictHostKeyChecking=no -i ${SSHKEY} ${CLOUD_SSHOPTS}
 RCLONE_OPTS=--s3-acl=public-read
 export SCW_FLAVOR=PRO2-M
 export SCW_VOLUME_TYPE=sbs_15k

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -119,7 +119,7 @@ endif
 dummy		    := $(shell touch artifacts)
 include ./artifacts
 
-SSHOPTS=-o "StrictHostKeyChecking no" -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
+SSHOPTS=-o StrictHostKeyChecking=no -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
 
 tag                 := $(shell [ -f "/usr/bin/git" ] && ((git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null) | sed 's/-.*//' | sed 's#[^A-Za-z0-9_.-]#-#g'))
 VERSION 		:= $(shell cat tagfiles.${CLOUD_CLI}.version | xargs -I '{}' find {} -type f -not -name '*.tar.gz'  | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -120,6 +120,7 @@ dummy		    := $(shell touch artifacts)
 include ./artifacts
 
 SSHOPTS=-o StrictHostKeyChecking=no -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
+REMOTE_ACTION_MAKEOVERRIDES := $(filter-out CLOUD_SSHOPTS=% SSHKEY_PRIVATE=% SSHKEY=% SSHKEYNAME=% SSHID=% ${HOME}/.ssh/config ${HOME}/.ssh/% %/.ssh/%,$(MAKEOVERRIDES))
 
 tag                 := $(shell [ -f "/usr/bin/git" ] && ((git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null) | sed 's/-.*//' | sed 's#[^A-Za-z0-9_.-]#-#g'))
 VERSION 		:= $(shell cat tagfiles.${CLOUD_CLI}.version | xargs -I '{}' find {} -type f -not -name '*.tar.gz'  | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')
@@ -1161,7 +1162,7 @@ remote-actions: remote-deploy
 			else\
 				MAKE_APP_PATH=${REMOTE_TOOLS_MAKE_PATH};\
 			fi;\
-			ssh ${SSHOPTS} $$U@$$H make -C $$MAKE_APP_PATH ${ACTIONS} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY} ${MAKEOVERRIDES};\
+			ssh ${SSHOPTS} $$U@$$H make -C $$MAKE_APP_PATH ${ACTIONS} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY} ${REMOTE_ACTION_MAKEOVERRIDES};\
 		fi
 
 remote-test-api-in-vpc: ${CLOUD}-instance-get-tagged-hosts

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -423,8 +423,8 @@ ${CLOUD_HOST_FILE}: ${CLOUD_DIR} ${CLOUD}-instance-get-host
 
 ${CLOUD}-instance-wait-ssh: ${CLOUD_FIRST_USER_FILE} ${CLOUD_HOST_FILE}
 	@if [ ! -f "${CLOUD_UP_FILE}" ];then\
-		HOST=$$(cat ${CLOUD_HOST_FILE});\
-		SSHUSER=$$(cat ${CLOUD_FIRST_USER_FILE});\
+		HOST=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+		SSHUSER=$$(tr -d '\r\n[:space:]' < ${CLOUD_FIRST_USER_FILE});\
 		(ssh-keygen -R $$HOST > /dev/null 2>&1) || true;\
 		timeout=${SSH_TIMEOUT} ; ret=1 ;\
 		until [ "$$timeout" -le 0 -o "$$ret" -eq "0"  ] ; do\
@@ -592,11 +592,11 @@ SCW-instance-get-host: SCW-instance-wait-running
 			SCW_NIC_ID=$$(cat ${CLOUD_NIC_FILE});\
 			curl -s "${SCW_IPAM_API}/ips" -H "X-Auth-Token: ${SCW_SECRET_TOKEN}"\
 				| jq -cr '.ips[]' | grep $$SCW_NIC_ID | grep '"is_ipv6":false'\
-				| jq -cr '.address' | sed 's|/.*||' \
+				| jq -cr '.address' | sed 's|/.*||' | tr -d '\r' \
 				> ${CLOUD_HOST_FILE};\
 		else\
 			curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" \
-				| jq -cr  ".servers[] | select (.id == \"$$SCW_SERVER_ID\") | .${SCW_IP}" \
+				| jq -cr  ".servers[] | select (.id == \"$$SCW_SERVER_ID\") | .${SCW_IP}" | tr -d '\r' \
 				> ${CLOUD_HOST_FILE};\
 		fi;\
 	fi
@@ -1055,8 +1055,8 @@ datagouv-get-files: ${DATAGOUV_CATALOG}
 remote-config-proxy: ${CONFIG_DIR} ${CLOUD_FIRST_USER_FILE}
 	@if [ ! -f "${CONFIG_REMOTE_PROXY_FILE}" ]; then\
 		if [ ! -z "${remote_http_proxy}" ]; then\
-			H=$$(cat ${CLOUD_HOST_FILE});\
-			U=$$(cat ${CLOUD_FIRST_USER_FILE});\
+			H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+			U=$$(tr -d '\r\n[:space:]' < ${CLOUD_FIRST_USER_FILE});\
 			if [ "${CLOUD}" == "SCW" ];then\
 				sudo="";\
 			else\
@@ -1085,8 +1085,8 @@ remote-config-proxy: ${CONFIG_DIR} ${CLOUD_FIRST_USER_FILE}
 ${CONFIG_REMOTE_FILE}: cloud-instance-up remote-config-proxy ${CONFIG_DIR}
 		@\
 		if [ ! -f "${CONFIG_REMOTE_FILE}" ];then\
-			H=$$(cat ${CLOUD_HOST_FILE});\
-			U=$$(cat ${CLOUD_USER_FILE});\
+			H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+			U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 			if [ "${CLOUD}" == "SCW" ];then\
 				ssh ${SSHOPTS} root@$$H apt-get install -o Dpkg::Options::="--force-confold" -yq sudo;\
 			fi;\
@@ -1105,21 +1105,21 @@ ${CONFIG_REMOTE_FILE}: cloud-instance-up remote-config-proxy ${CONFIG_DIR}
 
 remote-cmd: ${CLOUD_HOST_FILE} ${CLOUD_USER_FILE}
 	@\
-		H=$$(cat ${CLOUD_HOST_FILE});\
-		U=$$(cat ${CLOUD_USER_FILE});\
+		H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 		ssh ${SSHOPTS} $$U@$$H ${REMOTE_CMD};
 
 
 remote-docker-pull: ${CLOUD_HOST_FILE} ${CLOUD_USER_FILE}
 	@\
-		H=$$(cat ${CLOUD_HOST_FILE});\
-		U=$$(cat ${CLOUD_USER_FILE});\
+		H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 		ssh ${SSHOPTS} $$U@$$H docker pull ${DOCKER_IMAGE};
 
 remote-reboot-start: ${CLOUD_HOST_FILE} ${CLOUD_USER_FILE}
 		@\
-		H=$$(cat ${CLOUD_HOST_FILE});\
-		U=$$(cat ${CLOUD_USER_FILE});\
+		H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 		ssh ${SSHOPTS} $$U@$$H sudo reboot;\
 		echo ${CLOUD} instance is rebooting;\
 		rm ${CLOUD_UP_FILE};
@@ -1136,8 +1136,8 @@ remote-clean: cloud-instance-down
 ${CONFIG_APP_FILE}: ${CONFIG_REMOTE_FILE}
 		@\
 		if [ ! -f "${CONFIG_APP_FILE}" ];then\
-			H=$$(cat ${CLOUD_HOST_FILE});\
-			U=$$(cat ${CLOUD_USER_FILE});\
+			H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+			U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 			if [ "${APP}" != "${CLOUD_CLI}" ];then\
 				REMOTE_APP_BRANCH_OPT="";\
 				if [ -n "${REMOTE_APP_BRANCH}" ];then\
@@ -1153,8 +1153,8 @@ ${CONFIG_APP_FILE}: ${CONFIG_REMOTE_FILE}
 
 remote-actions: remote-deploy
 		@\
-		H=$$(cat ${CLOUD_HOST_FILE});\
-		U=$$(cat ${CLOUD_USER_FILE});\
+		H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 		if [ "${ACTIONS}" != "" ];then\
 			if [ "${APP}" != "${CLOUD_CLI}" ];then\
 				MAKE_APP_PATH=${REMOTE_APP_MAKE_PATH};\
@@ -1166,7 +1166,7 @@ remote-actions: remote-deploy
 
 remote-test-api-in-vpc: ${CLOUD}-instance-get-tagged-hosts
 	@if [ -f "${CONFIG_APP_FILE}" ];then\
-		U=$$(cat ${CLOUD_USER_FILE});\
+		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 		for H in $$(cat ${CLOUD_TAGGED_HOSTS_VPC_FILE});do\
 			(\
 				(\
@@ -1242,8 +1242,8 @@ remote-test-api:
 
 remote-install-root-aws-credentials:
 	@if [ ! -z "${STORAGE_ACCESS_KEY}" -a ! -z "${STORAGE_SECRET_KEY}" ];then\
-		H=$$(cat ${CLOUD_HOST_FILE});\
-		U=$$(cat ${CLOUD_USER_FILE});\
+		H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 		ssh ${SSHOPTS} $$U@$$H "sudo mkdir /root/.aws";\
 		cat ${TOOLS_PATH}/.aws/config | ssh ${SSHOPTS} $$U@$$H "sudo tee /root/.aws/config > /dev/null";\
 		cat ${TOOLS_PATH}/.aws/credentials | sed "s/<AWS_ACCESS_KEY_ID>/${STORAGE_ACCESS_KEY}/;s/<AWS_SECRET_ACCESS_KEY>/${STORAGE_SECRET_KEY}/;" | ssh ${SSHOPTS} $$U@$$H "sudo tee /root/.aws/credentials > /dev/null";\
@@ -1251,8 +1251,8 @@ remote-install-root-aws-credentials:
 
 remote-install-monitor: remote-install-root-aws-credentials
 	@if [ ! -z "${NEW_RELIC_API_KEY}" -a ! -z "${NEW_RELIC_ACCOUNT_ID}" ];then\
-		H=$$(cat ${CLOUD_HOST_FILE});\
-		U=$$(cat ${CLOUD_USER_FILE});\
+		H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 		cat ${TOOLS_PATH}/fluent-bit/plugins.conf | ssh ${SSHOPTS} $$U@$$H "sudo tee /tmp/plugins.conf > /dev/null";\
 		cat ${TOOLS_PATH}/fluent-bit/fluent-bit.conf | sed "s/<NEW_RELIC_INGEST_KEY>/${NEW_RELIC_INGEST_KEY}/;s|<HTTPS_PROXY>|${remote_http_proxy}|;s|<MONITOR_BUCKET>|${MONITOR_BUCKET}|;s|<MONITOR_DIR>|${MONITOR_DIR}|" | ssh ${SSHOPTS} $$U@$$H "sudo tee /tmp/fluent-bit.conf > /dev/null";\
 		ssh ${SSHOPTS} $$U@$$H "(sudo systemctl stop unattended-upgrades;sleep 30;curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo HTTPS_PROXY=${remote_http_proxy} NEW_RELIC_API_KEY=${NEW_RELIC_API_KEY} NEW_RELIC_ACCOUNT_ID=${NEW_RELIC_ACCOUNT_ID} NEW_RELIC_REGION=EU /usr/local/bin/newrelic install -y && echo New Relic Installed) > .install-newrelic.log 2>&1 &";\

--- a/spec/SPEC_EVOL_MAKE_CICD_CHECKLIST.md
+++ b/spec/SPEC_EVOL_MAKE_CICD_CHECKLIST.md
@@ -692,3 +692,34 @@ deces-dataprep    | remote-all               | packages/deces-dataprep   | year/
                   |                          | remote-all + REMOTE_*     | build             | 24777914592
                   |                          | vers monorepo matchID     | full/push-master  | full lot 9
 ```
+
+Revalidation `dataprep-year` du 2026-04-25:
+
+```text
+Run id      | SHA      | Resultat | Point prouve
+------------+----------+----------+---------------------------------------------------
+24942523131 | fc26b4c4 | failure  | `remote-all` reel reussi en 7m23; snapshot
+            |          |          | `esdata_7fdd43b0_e0735a1a` cree; VM SCW supprimee;
+            |          |          | echec seulement sur l'export metadata local
+24942735518 | 951e57d2 | success  | rerun vert avec snapshot deja present; aucune VM
+            |          |          | SCW recreee; export metadata ok apres retry
+```
+
+Details du run `24942523131`:
+
+- `Run dataprep year remote-all` passe de `22:49:39Z` a `22:57:02Z`.
+- Le bootstrap VM passe bien par le bastion, clone le monorepo, installe
+  `make`, `docker`, construit `matchid-backend-dev:7fdd43b0`, lance
+  `deces_dataprep`, cree le snapshot `esdata_7fdd43b0_e0735a1a`, puis
+  supprime l'instance SCW `f55d8f0f-1f68-45f0-b1b9-3f862f68dec7`.
+- La recette dataprep elle-meme termine en `0:49.298130` avec `679924` lignes
+  traitees et `679593` lignes ecrites.
+- L'echec restant ne portait pas sur le dataprep mais sur la relecture locale
+  immediate du snapshot pour l'artefact metadata.
+
+Decision:
+
+- la preuve forte du lot 8 n'est plus `24777914592` seul, car ce run etait un
+  cache-hit;
+- la preuve operationnelle retenue pour `dataprep-year` devient le couple
+  `24942523131` + `24942735518`.


### PR DESCRIPTION
## Scope
- restore bastion-based remote dataprep execution in CI/CD
- stabilize dataprep snapshot metadata export after remote runs
- document the validated year dataprep proof in the checklist

## Context
The first merge to  happened before these follow-up fixes were pushed on . This PR catches up  so the real  CD path can be rerun and validated on .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure & Security**
  * Enhanced SSH security with bastion host routing and validation for deployments
  * Improved deployment reliability with automatic retry logic for metadata capture
  * Better error handling and DNS resolution fallbacks during remote operations

* **Documentation**
  * Updated deployment validation records with new run evidence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->