### PR TITLE
fix: sanitize nginx deploy target secrets

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -371,12 +371,18 @@ jobs:
           }
           BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
           BASTION_USER_RESOLVED=ubuntu
+          NGINX_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
+          NGINX_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
           BASTION_SOURCE=nginx
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
+          if [ -z "${NGINX_HOST_RESOLVED}" ]; then NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"; fi
+          if [ -z "${NGINX_USER_RESOLVED}" ]; then NGINX_USER_RESOLVED=ubuntu; fi
           if [ -z "$(sanitize_host "${NGINX_HOST}")" ]; then BASTION_SOURCE=bastion; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
+          test -n "${NGINX_HOST_RESOLVED}"
+          test -n "${NGINX_USER_RESOLVED}"
           echo "bastion_source=${BASTION_SOURCE}"
           if printf '%s' "${BASTION_HOST_RESOLVED}" | grep -Eq '^[0-9.]+$'; then
             echo "bastion_input_host_kind=ip"
@@ -409,6 +415,8 @@ jobs:
           {
             echo "BASTION_HOST_RESOLVED=${BASTION_HOST_RESOLVED}"
             echo "BASTION_USER_RESOLVED=${BASTION_USER_RESOLVED}"
+            echo "NGINX_HOST_RESOLVED=${NGINX_HOST_RESOLVED}"
+            echo "NGINX_USER_RESOLVED=${NGINX_USER_RESOLVED}"
           } >> "${GITHUB_ENV}"
           sed -n 'l' "${HOME}/.ssh/config"
           chmod 600 "${HOME}/.ssh/config"
@@ -631,7 +639,7 @@ jobs:
             DEPLOY_TARGET=dev \
             APP_DNS=$APP_DNS \
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV REPOSITORY_BUCKET=$REPOSITORY_BUCKET_DEV \
-            NGINX_USER=$NGINX_USER NGINX_HOST=$NGINX_HOST \
+            NGINX_USER=$NGINX_USER_RESOLVED NGINX_HOST=$NGINX_HOST_RESOLVED \
             SMTP_TLS_SELFSIGNED=$SMTP_TLS_SELFSIGNED SMTP_HOST=$SMTP_HOST SMTP_PORT=$SMTP_PORT SMTP_USER=$SMTP_USER SMTP_PWD=$SMTP_PWD \
             remote_http_proxy=$remote_http_proxy remote_https_proxy=$remote_https_proxy remote_no_proxy=$remote_no_proxy \
             GOOGLE_ANALYTICS_ID=$GOOGLE_ANALYTICS_ID GOOGLE_ADSENSE_ID=$GOOGLE_ADSENSE_ID \

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -155,10 +155,16 @@ jobs:
           }
           BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
           BASTION_USER_RESOLVED=ubuntu
+          NGINX_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
+          NGINX_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
+          if [ -z "${NGINX_HOST_RESOLVED}" ]; then NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"; fi
+          if [ -z "${NGINX_USER_RESOLVED}" ]; then NGINX_USER_RESOLVED=ubuntu; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
+          test -n "${NGINX_HOST_RESOLVED}"
+          test -n "${NGINX_USER_RESOLVED}"
           if ! getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
             # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
             BASTION_HOST_RESOLVED=163.172.185.238
@@ -179,6 +185,8 @@ jobs:
           {
             echo "BASTION_HOST_RESOLVED=${BASTION_HOST_RESOLVED}"
             echo "BASTION_USER_RESOLVED=${BASTION_USER_RESOLVED}"
+            echo "NGINX_HOST_RESOLVED=${NGINX_HOST_RESOLVED}"
+            echo "NGINX_USER_RESOLVED=${NGINX_USER_RESOLVED}"
           } >> "${GITHUB_ENV}"
           chmod 600 "${HOME}/.ssh/config"
         env:
@@ -314,7 +322,7 @@ jobs:
             BACKEND_CHUNK_CONCURRENCY="${BACKEND_CHUNK_CONCURRENCY_PROD}" \
             ES_MEM="${ES_MEM_PROD}" \
             SCW_FLAVOR="${SCW_FLAVOR_PROD}" SCW_VOLUME_SIZE="${SCW_VOLUME_SIZE_PROD}" SCW_VOLUME_TYPE="${SCW_VOLUME_TYPE_PROD}" \
-            NGINX_USER="${NGINX_USER}" NGINX_HOST="${NGINX_HOST}" \
+            NGINX_USER="${NGINX_USER_RESOLVED}" NGINX_HOST="${NGINX_HOST_RESOLVED}" \
             SMTP_TLS_SELFSIGNED="${SMTP_TLS_SELFSIGNED}" SMTP_HOST="${SMTP_HOST}" SMTP_PORT="${SMTP_PORT}" SMTP_USER="${SMTP_USER}" SMTP_PWD="${SMTP_PWD}" \
             remote_http_proxy="${remote_http_proxy}" remote_https_proxy="${remote_https_proxy}" remote_no_proxy="${remote_no_proxy}" \
             GOOGLE_ANALYTICS_ID="${GOOGLE_ANALYTICS_ID}" GOOGLE_ADSENSE_ID="${GOOGLE_ADSENSE_ID}" \

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -236,10 +236,16 @@ jobs:
           }
           BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
           BASTION_USER_RESOLVED=ubuntu
+          NGINX_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
+          NGINX_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
+          if [ -z "${NGINX_HOST_RESOLVED}" ]; then NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"; fi
+          if [ -z "${NGINX_USER_RESOLVED}" ]; then NGINX_USER_RESOLVED=ubuntu; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
+          test -n "${NGINX_HOST_RESOLVED}"
+          test -n "${NGINX_USER_RESOLVED}"
           if ! getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
             # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
             BASTION_HOST_RESOLVED=163.172.185.238
@@ -260,6 +266,8 @@ jobs:
           {
             echo "BASTION_HOST_RESOLVED=${BASTION_HOST_RESOLVED}"
             echo "BASTION_USER_RESOLVED=${BASTION_USER_RESOLVED}"
+            echo "NGINX_HOST_RESOLVED=${NGINX_HOST_RESOLVED}"
+            echo "NGINX_USER_RESOLVED=${NGINX_USER_RESOLVED}"
           } >> "${GITHUB_ENV}"
           chmod 600 "${HOME}/.ssh/config"
         env:
@@ -411,7 +419,7 @@ jobs:
             BACKEND_CHUNK_CONCURRENCY="${BACKEND_CHUNK_CONCURRENCY_PROD}" \
             ES_MEM="${ES_MEM_PROD}" \
             SCW_FLAVOR="${SCW_FLAVOR_PROD}" SCW_VOLUME_SIZE="${SCW_VOLUME_SIZE_PROD}" SCW_VOLUME_TYPE="${SCW_VOLUME_TYPE_PROD}" \
-            NGINX_USER="${NGINX_USER}" NGINX_HOST="${NGINX_HOST}" \
+            NGINX_USER="${NGINX_USER_RESOLVED}" NGINX_HOST="${NGINX_HOST_RESOLVED}" \
             SMTP_TLS_SELFSIGNED="${SMTP_TLS_SELFSIGNED}" SMTP_HOST="${SMTP_HOST}" SMTP_PORT="${SMTP_PORT}" SMTP_USER="${SMTP_USER}" SMTP_PWD="${SMTP_PWD}" \
             remote_http_proxy="${remote_http_proxy}" remote_https_proxy="${remote_https_proxy}" remote_no_proxy="${remote_no_proxy}" \
             GOOGLE_ANALYTICS_ID="${GOOGLE_ANALYTICS_ID}" GOOGLE_ADSENSE_ID="${GOOGLE_ADSENSE_ID}" \


### PR DESCRIPTION
## Summary
- sanitize nginx host/user before invoking deploy make targets
- keep bastion resolution logic unchanged for app server access
- fix the remaining deploy failure seen in run 24944252693 after the nginx ssh option hotfix

## Validation
- compared the two failed deploy logs and isolated that the raw NGINX secret values were still passed into deploy-remote
- limited the change to cd/release workflows only
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow configurations across CD, monthly data prep, and production release pipelines to properly validate and sanitize deployment inputs with fallback defaults, improving overall deployment reliability and robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->