### PR TITLE
fix: block deploy when nginx target is unresolved

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -590,10 +590,16 @@ jobs:
           }
           BASTION_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
           BASTION_USER_RESOLVED=ubuntu
+          NGINX_HOST_RESOLVED="$(sanitize_host "${NGINX_HOST}")"
+          NGINX_USER_RESOLVED="$(sanitize_user "${NGINX_USER}")"
           if [ -z "${BASTION_HOST_RESOLVED}" ]; then BASTION_HOST_RESOLVED="$(sanitize_host "${BASTION_HOST}")"; fi
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
+          if [ -z "${NGINX_HOST_RESOLVED}" ]; then NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"; fi
+          if [ -z "${NGINX_USER_RESOLVED}" ]; then NGINX_USER_RESOLVED=ubuntu; fi
           test -n "${BASTION_HOST_RESOLVED}"
           test -n "${BASTION_USER_RESOLVED}"
+          test -n "${NGINX_HOST_RESOLVED}"
+          test -n "${NGINX_USER_RESOLVED}"
           if ! getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
             # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
             BASTION_HOST_RESOLVED=163.172.185.238
@@ -614,6 +620,8 @@ jobs:
           {
             echo "BASTION_HOST_RESOLVED=${BASTION_HOST_RESOLVED}"
             echo "BASTION_USER_RESOLVED=${BASTION_USER_RESOLVED}"
+            echo "NGINX_HOST_RESOLVED=${NGINX_HOST_RESOLVED}"
+            echo "NGINX_USER_RESOLVED=${NGINX_USER_RESOLVED}"
           } >> "${GITHUB_ENV}"
           chmod 600 "${HOME}/.ssh/config"
         env:

--- a/Makefile
+++ b/Makefile
@@ -532,7 +532,8 @@ deploy-remote-publish:
 	if [ -z "$$NGINX_HOST_EFFECTIVE" ]; then NGINX_HOST_EFFECTIVE="${NGINX_HOST_RESOLVED}"; fi;\
 	if [ -z "$$NGINX_USER_EFFECTIVE" ]; then NGINX_USER_EFFECTIVE="${NGINX_USER_RESOLVED}"; fi;\
 	if [ -z "$$NGINX_HOST_EFFECTIVE" -o -z "$$NGINX_USER_EFFECTIVE" ];then\
-		(echo "can't deploy without NGINX_HOST and NGINX_USER" && exit 1);\
+		echo "can't deploy without NGINX_HOST and NGINX_USER";\
+		exit 1;\
 	fi;\
 	BACKEND_APP_VERSION=${DECES_BACKEND_APP_VERSION};\
 	DATAPREP_VERSION=$$(cat ${DATAPREP_VERSION_FILE});\


### PR DESCRIPTION
## Summary
- make deploy-remote-publish fail hard when no effective nginx target is available
- export resolved nginx host/user in the dev Deploy job before invoking make deploy-remote

## Verification
- make deploy-remote-publish MAKE=true NGINX_HOST= NGINX_USER= APP_DNS_TARGET=test.example APP_VERSION=test DECES_BACKEND_APP_VERSION=test GIT_BRANCH=dev DATAPREP_VERSION_FILE=/tmp/dataprep.version.test DATA_VERSION_FILE=/tmp/data.version.test
- make deploy-remote-publish MAKE=true NGINX_HOST= NGINX_USER= NGINX_HOST_RESOLVED=resolved-host NGINX_USER_RESOLVED=resolved-user APP_DNS_TARGET=test.example APP_VERSION=test DECES_BACKEND_APP_VERSION=test GIT_BRANCH=dev DATAPREP_VERSION_FILE=/tmp/dataprep.version.test DATA_VERSION_FILE=/tmp/data.version.test
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved deployment infrastructure reliability through enhanced host and user configuration resolution with automatic fallback mechanisms.
  * Refined deployment script error handling for better robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->