### PR TITLE
fix: isolate nginx ssh from runner config

### DIFF
--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -120,7 +120,9 @@ dummy		    := $(shell touch artifacts)
 include ./artifacts
 
 SSHOPTS=-o StrictHostKeyChecking=no -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
-NGINX_SSHOPTS=-o StrictHostKeyChecking=no -i ${SSHKEY_PRIVATE}
+# Nginx publication must connect directly to the bastion/nginx host, even when
+# the runner injects a global ~/.ssh/config ProxyJump for SCW instances.
+NGINX_SSHOPTS=-F /dev/null -o ProxyJump=none -o StrictHostKeyChecking=no -i ${SSHKEY_PRIVATE}
 REMOTE_ACTION_MAKEOVERRIDES := $(filter-out CLOUD_SSHOPTS=% SSHKEY_PRIVATE=% SSHKEY=% SSHKEYNAME=% SSHID=% ${HOME}/.ssh/config ${HOME}/.ssh/% %/.ssh/%,$(MAKEOVERRIDES))
 
 tag                 := $(shell [ -f "/usr/bin/git" ] && ((git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null) | sed 's/-.*//' | sed 's#[^A-Za-z0-9_.-]#-#g'))


### PR DESCRIPTION
## Summary
- isolate nginx SSH calls from runner-level ~/.ssh/config
- force direct connection to the nginx/bastion host during publish
- keep the existing SCW instance SSH path unchanged

## Validation
- reproduced runner-only SSH config interference locally with a hostile ssh config
- verified direct ssh passes with -F /dev/null -o ProxyJump=none
- reran local make deploy-remote-publish end-to-end successfully against dev-deces
- verified public dev backend/search respond on bb204d0
