### PR TITLE
fix: reuse bastion target for nginx publish

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -379,10 +379,6 @@ jobs:
           if [ -z "${NGINX_HOST_RESOLVED}" ]; then NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"; fi
           if [ -z "${NGINX_USER_RESOLVED}" ]; then NGINX_USER_RESOLVED=ubuntu; fi
           if [ -z "$(sanitize_host "${NGINX_HOST}")" ]; then BASTION_SOURCE=bastion; fi
-          test -n "${BASTION_HOST_RESOLVED}"
-          test -n "${BASTION_USER_RESOLVED}"
-          test -n "${NGINX_HOST_RESOLVED}"
-          test -n "${NGINX_USER_RESOLVED}"
           echo "bastion_source=${BASTION_SOURCE}"
           if printf '%s' "${BASTION_HOST_RESOLVED}" | grep -Eq '^[0-9.]+$'; then
             echo "bastion_input_host_kind=ip"
@@ -399,6 +395,13 @@ jobs:
             echo "bastion_source=${BASTION_SOURCE}"
             echo "bastion_input_host_kind=ip"
           fi
+          # Current deploy topology publishes nginx through the bastion host.
+          NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"
+          NGINX_USER_RESOLVED="${BASTION_USER_RESOLVED}"
+          test -n "${BASTION_HOST_RESOLVED}"
+          test -n "${BASTION_USER_RESOLVED}"
+          test -n "${NGINX_HOST_RESOLVED}"
+          test -n "${NGINX_USER_RESOLVED}"
           printf '%s\n' \
             "Host bastion" \
             "  HostName ${BASTION_HOST_RESOLVED}" \
@@ -596,14 +599,17 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           if [ -z "${NGINX_HOST_RESOLVED}" ]; then NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"; fi
           if [ -z "${NGINX_USER_RESOLVED}" ]; then NGINX_USER_RESOLVED=ubuntu; fi
-          test -n "${BASTION_HOST_RESOLVED}"
-          test -n "${BASTION_USER_RESOLVED}"
-          test -n "${NGINX_HOST_RESOLVED}"
-          test -n "${NGINX_USER_RESOLVED}"
           if ! getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
             # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
             BASTION_HOST_RESOLVED=163.172.185.238
           fi
+          # Current deploy topology publishes nginx through the bastion host.
+          NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"
+          NGINX_USER_RESOLVED="${BASTION_USER_RESOLVED}"
+          test -n "${BASTION_HOST_RESOLVED}"
+          test -n "${BASTION_USER_RESOLVED}"
+          test -n "${NGINX_HOST_RESOLVED}"
+          test -n "${NGINX_USER_RESOLVED}"
           printf '%s\n' \
             "Host bastion" \
             "  HostName ${BASTION_HOST_RESOLVED}" \

--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -161,14 +161,17 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           if [ -z "${NGINX_HOST_RESOLVED}" ]; then NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"; fi
           if [ -z "${NGINX_USER_RESOLVED}" ]; then NGINX_USER_RESOLVED=ubuntu; fi
-          test -n "${BASTION_HOST_RESOLVED}"
-          test -n "${BASTION_USER_RESOLVED}"
-          test -n "${NGINX_HOST_RESOLVED}"
-          test -n "${NGINX_USER_RESOLVED}"
           if ! getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
             # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
             BASTION_HOST_RESOLVED=163.172.185.238
           fi
+          # Current deploy topology publishes nginx through the bastion host.
+          NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"
+          NGINX_USER_RESOLVED="${BASTION_USER_RESOLVED}"
+          test -n "${BASTION_HOST_RESOLVED}"
+          test -n "${BASTION_USER_RESOLVED}"
+          test -n "${NGINX_HOST_RESOLVED}"
+          test -n "${NGINX_USER_RESOLVED}"
           printf '%s\n' \
             "Host bastion" \
             "  HostName ${BASTION_HOST_RESOLVED}" \

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -242,14 +242,17 @@ jobs:
           if [ -z "${BASTION_USER_RESOLVED}" ]; then BASTION_USER_RESOLVED="$(sanitize_user "${BASTION_USER}")"; fi
           if [ -z "${NGINX_HOST_RESOLVED}" ]; then NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"; fi
           if [ -z "${NGINX_USER_RESOLVED}" ]; then NGINX_USER_RESOLVED=ubuntu; fi
-          test -n "${BASTION_HOST_RESOLVED}"
-          test -n "${BASTION_USER_RESOLVED}"
-          test -n "${NGINX_HOST_RESOLVED}"
-          test -n "${NGINX_USER_RESOLVED}"
           if ! getent hosts "${BASTION_HOST_RESOLVED}" >/dev/null 2>&1; then
             # Temporary fallback while monorepo runner secrets still expose a non-resolving bastion host.
             BASTION_HOST_RESOLVED=163.172.185.238
           fi
+          # Current deploy topology publishes nginx through the bastion host.
+          NGINX_HOST_RESOLVED="${BASTION_HOST_RESOLVED}"
+          NGINX_USER_RESOLVED="${BASTION_USER_RESOLVED}"
+          test -n "${BASTION_HOST_RESOLVED}"
+          test -n "${BASTION_USER_RESOLVED}"
+          test -n "${NGINX_HOST_RESOLVED}"
+          test -n "${NGINX_USER_RESOLVED}"
           printf '%s\n' \
             "Host bastion" \
             "  HostName ${BASTION_HOST_RESOLVED}" \


### PR DESCRIPTION
## Summary
- reuse the resolved bastion host/user for nginx publication in CD workflows
- keep dataprep and prod workflows aligned with the same publish target
- preserve the current deploy topology without changing deploy artefacts

## Verification
- local faithful replay of the publish step with versions c21ddfa / 7fdd43b0 / e0735a1a
- verified generated upstream points to 51.15.247.64:8083
- verified dev-deces version endpoint returns backend c21ddfa
- verified search smoke on dev-deces returns one result for dupont/jean/2020/33


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment workflow configurations to improve SSH connectivity reliability across bastion-based infrastructure. Enhanced validation and host resolution logic in continuous deployment, monthly data preparation, and production release pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->