### PR TITLE
fix: reuse main images on prod release

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -65,6 +65,7 @@ jobs:
           TAG_SHA=$(git rev-list -n 1 "${PROD_TAG}")
           git merge-base --is-ancestor "${TAG_SHA}" origin/main
           PREVIOUS_PROD_TAG=$(git tag --list 'v*' --sort=-creatordate | grep -Fxv "${PROD_TAG}" | head -n 1 || true)
+          COMMIT_SHORT=$(git rev-parse --short "${TAG_SHA}")
           DATAPREP_CHANGED=true
           if [ -n "${PREVIOUS_PROD_TAG}" ]; then
             if git diff --quiet "${PREVIOUS_PROD_TAG}" "${PROD_TAG}" -- \
@@ -81,6 +82,7 @@ jobs:
           {
             echo "prod_tag=${PROD_TAG}"
             echo "tag_sha=${TAG_SHA}"
+            echo "commit_short=${COMMIT_SHORT}"
             echo "previous_prod_tag=${PREVIOUS_PROD_TAG}"
             echo "dataprep_changed=${DATAPREP_CHANGED}"
           } >> "${GITHUB_OUTPUT}"
@@ -136,61 +138,21 @@ jobs:
             echo "data_version=${DATA_VERSION}"
           } >> "${GITHUB_OUTPUT}"
 
-      - name: Promote first prod tag to full dataprep
-        if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
-        run: echo "prod release will publish a new full snapshot"
-
-      - name: Build deces-backend image
-        run: make -C packages/deces-backend DATA_DIR=data NPM_AUDIT_DRY_RUN=true backend-build-image GIT_BRANCH=master
-
-      - name: Publish deces-backend image
-        run: make -C packages/deces-backend docker-push-backend GIT_BRANCH=master
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build deces-ui image
-        run: make APP=deces-ui build GIT_BRANCH=master
-
-      - name: Publish deces-ui image
-        run: make frontend-docker-push GIT_BRANCH=master
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build matchid-backend image
-        if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
+      - name: Resolve published image versions
+        id: images
         run: |
-          make -C packages/deces-dataprep config GIT_BRANCH=master
-          make -C packages/dataprep-backend backend-build GIT_BRANCH=master
-
-      - name: Publish matchid-backend image
-        if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
-        run: make -C packages/dataprep-backend backend-docker-push GIT_BRANCH=master
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Publish legacy matchID package
-        if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
-        run: |
-          make -C packages/deces-dataprep config frontend-config GIT_BRANCH=master
-          make -C packages/dataprep-backend package-publish GIT_BRANCH=master GIT_FRONTEND_BRANCH=master
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
-          STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
-          STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
-
-      - name: Build matchid-frontend image
-        if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
-        run: |
-          make -C packages/deces-dataprep config frontend-config GIT_BRANCH=master
-          make -C packages/dataprep-frontend build GIT_BRANCH=master GIT_BACKEND_BRANCH=master
-        env:
-          NPM_AUDIT_IGNORE: "true"
-
-      - name: Publish matchid-frontend image
-        if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
-        run: make -C packages/dataprep-frontend frontend-docker-push GIT_BRANCH=master GIT_BACKEND_BRANCH=master
-        env:
-          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+          set -euo pipefail
+          COMMIT_SHORT="${{ steps.context.outputs.commit_short }}"
+          DATAPREP_BACKEND_IMAGE_VERSION=
+          if [ "${{ steps.context.outputs.dataprep_changed }}" = "true" ] || [ "${{ steps.snapshot.outputs.run_full }}" = "true" ]; then
+            CURRENT_DATAPREP_BACKEND_VERSION=$(make -s -C packages/dataprep-backend version GIT_BRANCH=master | awk '{print $NF}')
+            DATAPREP_BACKEND_IMAGE_VERSION="${COMMIT_SHORT}-${CURRENT_DATAPREP_BACKEND_VERSION##*-}"
+          fi
+          {
+            echo "deces_ui_image_version=${COMMIT_SHORT}"
+            echo "deces_backend_image_version=${COMMIT_SHORT}"
+            echo "dataprep_backend_image_version=${DATAPREP_BACKEND_IMAGE_VERSION}"
+          } >> "${GITHUB_OUTPUT}"
 
       - name: Install deploy SSH key
         run: |
@@ -299,11 +261,13 @@ jobs:
             SLACK_TITLE="deces-dataprep - full" SLACK_WEBHOOK="${SLACK_WEBHOOK}" \
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
+            DATAPREP_BACKEND_MAKEOVERRIDES="APP_VERSION=${DATAPREP_BACKEND_IMAGE_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
             CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
+          DATAPREP_BACKEND_IMAGE_VERSION: ${{ steps.images.outputs.dataprep_backend_image_version }}
           PROD_TAG: ${{ steps.context.outputs.prod_tag }}
           remote_http_proxy: ${{ secrets.remote_http_proxy }}
           remote_https_proxy: ${{ secrets.remote_https_proxy }}
@@ -397,9 +361,13 @@ jobs:
           NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           MONITOR_BUCKET: ${{ secrets.MONITOR_BUCKET }}
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+          DECES_UI_IMAGE_VERSION: ${{ steps.images.outputs.deces_ui_image_version }}
+          DECES_BACKEND_IMAGE_VERSION: ${{ steps.images.outputs.deces_backend_image_version }}
         run: |
           make deploy-remote-preflight \
             GIT_BRANCH=master \
+            APP_VERSION="${DECES_UI_IMAGE_VERSION}" \
+            DECES_BACKEND_APP_VERSION="${DECES_BACKEND_IMAGE_VERSION}" \
             GIT_BACKEND_BRANCH=master \
             REMOTE_DEPLOY_BRANCH="${PROD_TAG}" \
             DEPLOY_TARGET=prod \
@@ -411,6 +379,8 @@ jobs:
             CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
           make deploy-remote \
             GIT_BRANCH=master \
+            APP_VERSION="${DECES_UI_IMAGE_VERSION}" \
+            DECES_BACKEND_APP_VERSION="${DECES_BACKEND_IMAGE_VERSION}" \
             GIT_BACKEND_BRANCH=master \
             REMOTE_DEPLOY_BRANCH="${PROD_TAG}" \
             DEPLOY_TARGET=prod \


### PR DESCRIPTION
## Summary
- reuse deces-ui and deces-backend images already published on main during prod release
- reuse the existing matchid-backend image for dataprep full instead of rebuilding on tag
- stop triggering heavy rebuilds when only .github/workflows/cd.yml changes

## Validation
- YAML parse for .github/workflows/release-prod.yml and .github/workflows/cd.yml
- git diff --check
- confirmed no Makefile changes in this branch
