### PR TITLE
ci: align pr validation and manual redeploys

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -300,9 +300,11 @@ jobs:
         ) ||
         (
           github.event_name == 'workflow_dispatch' &&
+          github.ref == 'refs/heads/main' &&
           (
             inputs.dataprep_scope == 'all' ||
-            inputs.dataprep_scope == 'year'
+            inputs.dataprep_scope == 'year' ||
+            inputs.deploy_target == 'dev'
           )
         ) ||
         (
@@ -327,7 +329,37 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref || github.ref }}
+      - name: Resolve dataprep year execution context
+        id: year_context
+        run: |
+          set -euo pipefail
+          SHOULD_RUN=true
+          REASON=push_or_repository_dispatch
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ]; then
+            if [ "${INPUT_DATAPREP_SCOPE}" = "all" ] || [ "${INPUT_DATAPREP_SCOPE}" = "year" ]; then
+              REASON=explicit_year_dispatch
+            elif [ "${INPUT_DEPLOY_TARGET}" = "dev" ]; then
+              rm -f packages/deces-dataprep/repository-check
+              make -C packages/deces-dataprep repository-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
+              if test -s packages/deces-dataprep/repository-check; then
+                SHOULD_RUN=false
+                REASON=year_snapshot_present
+              else
+                REASON=year_snapshot_missing
+              fi
+            fi
+          fi
+          {
+            echo "should_run=${SHOULD_RUN}"
+            echo "reason=${REASON}"
+          } >> "${GITHUB_OUTPUT}"
+        env:
+          INPUT_DATAPREP_SCOPE: ${{ inputs.dataprep_scope || 'none' }}
+          INPUT_DEPLOY_TARGET: ${{ inputs.deploy_target || 'none' }}
+          STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
+          STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
       - name: Install dataprep deploy SSH key
+        if: steps.year_context.outputs.should_run == 'true'
         run: |
           test -n "${SSH_PRIVATE_KEY}"
           install -m 700 -d "${HOME}/.ssh"
@@ -430,6 +462,7 @@ jobs:
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Debug dataprep bastion resolution
+        if: steps.year_context.outputs.should_run == 'true'
         run: |
           set -euo pipefail
           PROXY_ROUTE="$(ssh -G -F "${HOME}/.ssh/config" 10.0.0.1 | awk '
@@ -445,11 +478,13 @@ jobs:
             exit 1
           fi
       - name: Check dataprep year snapshot
+        if: steps.year_context.outputs.should_run == 'true'
         run: make -C packages/deces-dataprep clean full-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
         env:
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
       - name: Run dataprep year remote-all
+        if: steps.year_context.outputs.should_run == 'true'
         run: |
           make -C packages/deces-dataprep remote-all \
             GIT_BRANCH=dev \
@@ -477,6 +512,7 @@ jobs:
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
       - name: Export dataprep year snapshot metadata
+        if: steps.year_context.outputs.should_run == 'true'
         run: |
           rm -f packages/deces-dataprep/repository-check
           for attempt in $(seq 1 12); do
@@ -499,6 +535,7 @@ jobs:
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
       - name: Upload dataprep year snapshot metadata
+        if: steps.year_context.outputs.should_run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: dataprep-year-snapshot-metadata

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - main
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -91,6 +88,7 @@ jobs:
     if: needs.changes.outputs.dataprep_backend == 'true'
     runs-on: ubuntu-latest
     env:
+      GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
       TOOLS_PATH: ${{ github.workspace }}/packages/tools
       DATAPREP_PROJECT_NAME: deces-dataprep
       DATAPREP_PROJECT_SOURCE_PATH: ${{ github.workspace }}/packages/deces-dataprep/projects/deces-dataprep
@@ -101,7 +99,7 @@ jobs:
       - name: Configure monorepo dataprep backend
         run: make -C packages/deces-dataprep config
       - name: Build or reuse backend image and run tests
-        run: make -C packages/dataprep-backend version backend-docker-check GIT_BRANCH=${GITHUB_REF_NAME} || ( make -C packages/dataprep-backend backend-build GIT_BRANCH=${GITHUB_REF_NAME} && make -C packages/dataprep-backend backend tests backend-stop GIT_BRANCH=${GITHUB_REF_NAME} )
+        run: make -C packages/dataprep-backend version backend-docker-check GIT_BRANCH=${GIT_BRANCH} || ( make -C packages/dataprep-backend backend-build GIT_BRANCH=${GIT_BRANCH} && make -C packages/dataprep-backend backend tests backend-stop GIT_BRANCH=${GIT_BRANCH} )
 
   dataprep-frontend-test:
     name: dataprep-frontend pull request test
@@ -128,18 +126,34 @@ jobs:
           make -C packages/dataprep-frontend frontend-docker-check GIT_BRANCH=dev GIT_BACKEND_BRANCH=dev || make -C packages/dataprep-frontend build backend-docker-check up GIT_BRANCH=dev GIT_BACKEND_BRANCH=dev
 
   deces-backend-build:
-    name: deces-backend build docker image and tests
+    name: deces-backend build docker image
     needs: changes
     if: needs.changes.outputs.deces_backend == 'true'
     runs-on: ubuntu-latest
+    env:
+      GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Build backend image
-        run: make -C packages/deces-backend DATA_DIR=data NPM_AUDIT_DRY_RUN=true backend-build-image GIT_BRANCH=${GITHUB_REF_NAME}
+        run: make -C packages/deces-backend DATA_DIR=data NPM_AUDIT_DRY_RUN=true backend-build-image GIT_BRANCH=${GIT_BRANCH}
+
+  deces-backend-tests:
+    name: deces-backend tests
+    needs: changes
+    if: needs.changes.outputs.deces_backend == 'true'
+    runs-on: ubuntu-latest
+    env:
+      GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build backend image
+        run: make -C packages/deces-backend DATA_DIR=data NPM_AUDIT_DRY_RUN=true backend-build-image GIT_BRANCH=${GIT_BRANCH}
       - name: Make deploy dependencies
-        run: make -C packages/deces-backend NPM_AUDIT_DRY_RUN=true deploy-dependencies GIT_BRANCH=${GITHUB_REF_NAME}
+        run: make -C packages/deces-backend NPM_AUDIT_DRY_RUN=true deploy-dependencies GIT_BRANCH=${GIT_BRANCH}
         env:
           FILES_TO_PROCESS: deces-2020-m01.txt.gz
           REPOSITORY_BUCKET: fichier-des-personnes-decedees-elasticsearch-dev
@@ -147,10 +161,42 @@ jobs:
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
       - name: Run backend vitest tests
-        run: make -C packages/deces-backend DATA_DIR=${GITHUB_WORKSPACE}/packages/deces-backend/data NPM_AUDIT_DRY_RUN=true backend-test-vitest GIT_BRANCH=${GITHUB_REF_NAME}
+        run: make -C packages/deces-backend DATA_DIR=${GITHUB_WORKSPACE}/packages/deces-backend/data NPM_AUDIT_DRY_RUN=true backend-test-vitest GIT_BRANCH=${GIT_BRANCH}
       - name: Stop backend test dependencies
         if: always()
-        run: make -C packages/deces-backend backend-redis-stop backend-smtp-stop GIT_BRANCH=${GITHUB_REF_NAME}
+        run: make -C packages/deces-backend backend-redis-stop backend-smtp-stop GIT_BRANCH=${GIT_BRANCH}
+
+  deces-backend-artillery:
+    name: deces-backend perf artillery
+    needs: changes
+    if: needs.changes.outputs.deces_backend == 'true'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    env:
+      GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build backend image
+        run: make -C packages/deces-backend DATA_DIR=data NPM_AUDIT_DRY_RUN=true backend-build-image GIT_BRANCH=${GIT_BRANCH}
+      - name: Make deploy dependencies
+        run: make -C packages/deces-backend NPM_AUDIT_DRY_RUN=true deploy-dependencies GIT_BRANCH=${GIT_BRANCH}
+        env:
+          FILES_TO_PROCESS: deces-2020-m01.txt.gz
+          REPOSITORY_BUCKET: fichier-des-personnes-decedees-elasticsearch-dev
+          ES_MEM: 1024m
+          STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
+          STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
+      - name: Start backend stack
+        run: make -C packages/deces-backend backend-start GIT_BRANCH=${GIT_BRANCH}
+      - name: Run artillery scenario
+        run: make -C packages/deces-backend test-perf-v1 GIT_BRANCH=${GIT_BRANCH}
+      - name: Stop perf dependencies
+        if: always()
+        run: |
+          make -C packages/deces-backend backend-stop backend-redis-stop backend-smtp-stop GIT_BRANCH=${GIT_BRANCH}
+          make -C packages/deces-infra elasticsearch-stop GIT_BRANCH=${GIT_BRANCH}
 
   deces-ui-pull-request-test:
     name: deces-ui pull request test
@@ -197,13 +243,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.deces_dataprep == 'true'
     runs-on: ubuntu-latest
+    env:
+      GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Run small dataset
         run: |
-          make -C packages/deces-dataprep all FILES_TO_PROCESS=${FILES_TO_PROCESS} \
+          make -C packages/deces-dataprep all GIT_BRANCH=${GIT_BRANCH} FILES_TO_PROCESS=${FILES_TO_PROCESS} \
             REPOSITORY_BUCKET=${REPOSITORY_BUCKET} \
             CHUNK_SIZE=${CHUNK_SIZE} ES_THREADS=${ES_THREADS} RECIPE_THREADS=${RECIPE_THREADS} ES_MEM=${ES_MEM}
         env:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -10,6 +10,15 @@ on:
         description: Prod tag to release
         required: true
         type: string
+      release_mode:
+        description: Prod release mode
+        required: false
+        default: auto
+        type: choice
+        options:
+          - auto
+          - deploy_only
+          - full_and_deploy
 
 concurrency:
   group: release-prod-${{ github.event.inputs.prod_tag || github.ref_name }}
@@ -51,13 +60,22 @@ jobs:
         id: context
         env:
           INPUT_PROD_TAG: ${{ inputs.prod_tag }}
+          INPUT_RELEASE_MODE: ${{ inputs.release_mode }}
         run: |
           set -euo pipefail
           PROD_TAG="${INPUT_PROD_TAG:-${GITHUB_REF_NAME}}"
+          RELEASE_MODE="${INPUT_RELEASE_MODE:-auto}"
           case "${PROD_TAG}" in
             v*) ;;
             *)
               echo "prod tag must match v*"
+              exit 1
+              ;;
+          esac
+          case "${RELEASE_MODE}" in
+            auto|deploy_only|full_and_deploy) ;;
+            *)
+              echo "release mode must be one of auto, deploy_only, full_and_deploy"
               exit 1
               ;;
           esac
@@ -85,11 +103,12 @@ jobs:
             echo "commit_short=${COMMIT_SHORT}"
             echo "previous_prod_tag=${PREVIOUS_PROD_TAG}"
             echo "dataprep_changed=${DATAPREP_CHANGED}"
+            echo "release_mode=${RELEASE_MODE}"
           } >> "${GITHUB_OUTPUT}"
 
       - name: Resolve existing prod snapshot metadata
-        id: snapshot
-        if: steps.context.outputs.dataprep_changed != 'true'
+        id: snapshot_auto
+        if: steps.context.outputs.release_mode == 'auto' && steps.context.outputs.dataprep_changed != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -138,13 +157,79 @@ jobs:
             echo "data_version=${DATA_VERSION}"
           } >> "${GITHUB_OUTPUT}"
 
+      - name: Resolve tagged prod snapshot metadata
+        id: snapshot_tagged
+        if: steps.context.outputs.release_mode == 'deploy_only'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_SHA: ${{ steps.context.outputs.tag_sha }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/actions/workflows/release-prod.yml/runs?status=completed&per_page=100" > /tmp/release-prod-runs.json
+          SOURCE_RUN_ID=$(
+            jq -r --argjson current "${GITHUB_RUN_ID}" --arg tag_sha "${TAG_SHA}" '
+              .workflow_runs[]
+              | select(.id != $current and .conclusion == "success" and .head_sha == $tag_sha)
+              | .id
+            ' /tmp/release-prod-runs.json | head -n 1
+          )
+          if [ -z "${SOURCE_RUN_ID}" ]; then
+            echo "missing_metadata=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${SOURCE_RUN_ID}/artifacts" > /tmp/release-prod-artifacts.json
+          ARTIFACT_URL=$(
+            jq -r '
+              .artifacts[]
+              | select(.name == "release-prod-metadata")
+              | .archive_download_url
+            ' /tmp/release-prod-artifacts.json | head -n 1
+          )
+          if [ -z "${ARTIFACT_URL}" ]; then
+            echo "missing_metadata=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          curl -fsSL \
+            -H "Authorization: Bearer ${GH_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "${ARTIFACT_URL}" \
+            -o /tmp/release-prod-metadata.zip
+          unzip -p /tmp/release-prod-metadata.zip release-prod-metadata.txt > /tmp/release-prod-metadata.txt
+          SNAPSHOT_NAME=$(sed -n 's/^snapshot_name=//p' /tmp/release-prod-metadata.txt)
+          DATAPREP_VERSION=$(sed -n 's/^dataprep_version=//p' /tmp/release-prod-metadata.txt)
+          DATA_VERSION=$(sed -n 's/^data_version=//p' /tmp/release-prod-metadata.txt)
+          if [ -z "${SNAPSHOT_NAME}" ] || [ -z "${DATAPREP_VERSION}" ] || [ -z "${DATA_VERSION}" ]; then
+            echo "missing_metadata=true" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+          {
+            echo "missing_metadata=false"
+            echo "snapshot_name=${SNAPSHOT_NAME}"
+            echo "dataprep_version=${DATAPREP_VERSION}"
+            echo "data_version=${DATA_VERSION}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Validate deploy-only metadata
+        if: steps.context.outputs.release_mode == 'deploy_only' && steps.snapshot_tagged.outputs.missing_metadata == 'true'
+        run: |
+          echo "missing successful release-prod metadata for ${PROD_TAG}"
+          exit 1
+        env:
+          PROD_TAG: ${{ steps.context.outputs.prod_tag }}
+
       - name: Resolve published image versions
         id: images
         run: |
           set -euo pipefail
           COMMIT_SHORT="${{ steps.context.outputs.commit_short }}"
           DATAPREP_BACKEND_IMAGE_VERSION=
-          if [ "${{ steps.context.outputs.dataprep_changed }}" = "true" ] || [ "${{ steps.snapshot.outputs.run_full }}" = "true" ]; then
+          RUN_FULL=false
+          if [ "${{ steps.context.outputs.release_mode }}" = "full_and_deploy" ]; then
+            RUN_FULL=true
+          elif [ "${{ steps.context.outputs.release_mode }}" = "auto" ] && { [ "${{ steps.context.outputs.dataprep_changed }}" = "true" ] || [ "${{ steps.snapshot_auto.outputs.run_full }}" = "true" ]; }; then
+            RUN_FULL=true
+          fi
+          if [ "${RUN_FULL}" = "true" ]; then
             CURRENT_DATAPREP_BACKEND_VERSION=$(make -s -C packages/dataprep-backend version GIT_BRANCH=master | awk '{print $NF}')
             DATAPREP_BACKEND_IMAGE_VERSION="${COMMIT_SHORT}-${CURRENT_DATAPREP_BACKEND_VERSION##*-}"
           fi
@@ -243,14 +328,14 @@ jobs:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
 
       - name: Check dataprep full snapshot
-        if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
+        if: steps.context.outputs.release_mode == 'full_and_deploy' || (steps.context.outputs.release_mode == 'auto' && (steps.context.outputs.dataprep_changed == 'true' || steps.snapshot_auto.outputs.run_full == 'true'))
         run: make -C packages/deces-dataprep clean full-check GIT_BRANCH=master REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}"
         env:
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
 
       - name: Run dataprep full remote-all
-        if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
+        if: steps.context.outputs.release_mode == 'full_and_deploy' || (steps.context.outputs.release_mode == 'auto' && (steps.context.outputs.dataprep_changed == 'true' || steps.snapshot_auto.outputs.run_full == 'true'))
         run: |
           make -C packages/deces-dataprep remote-all \
             GIT_BRANCH=master \
@@ -281,7 +366,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
 
       - name: Capture prod snapshot metadata
-        if: steps.context.outputs.dataprep_changed == 'true' || steps.snapshot.outputs.run_full == 'true'
+        if: steps.context.outputs.release_mode == 'full_and_deploy' || (steps.context.outputs.release_mode == 'auto' && (steps.context.outputs.dataprep_changed == 'true' || steps.snapshot_auto.outputs.run_full == 'true'))
         run: |
           set -euo pipefail
           rm -f packages/deces-dataprep/repository-check
@@ -307,7 +392,7 @@ jobs:
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
 
       - name: Reuse current prod snapshot metadata
-        if: steps.context.outputs.dataprep_changed != 'true' && steps.snapshot.outputs.run_full == 'false'
+        if: steps.context.outputs.release_mode == 'auto' && steps.context.outputs.dataprep_changed != 'true' && steps.snapshot_auto.outputs.run_full == 'false'
         run: |
           {
             echo "SNAPSHOT_NAME=${SNAPSHOT_NAME}"
@@ -315,9 +400,22 @@ jobs:
             echo "DATA_VERSION=${DATA_VERSION}"
           } >> "${GITHUB_ENV}"
         env:
-          SNAPSHOT_NAME: ${{ steps.snapshot.outputs.snapshot_name }}
-          DATAPREP_VERSION: ${{ steps.snapshot.outputs.dataprep_version }}
-          DATA_VERSION: ${{ steps.snapshot.outputs.data_version }}
+          SNAPSHOT_NAME: ${{ steps.snapshot_auto.outputs.snapshot_name }}
+          DATAPREP_VERSION: ${{ steps.snapshot_auto.outputs.dataprep_version }}
+          DATA_VERSION: ${{ steps.snapshot_auto.outputs.data_version }}
+
+      - name: Reuse tagged prod snapshot metadata
+        if: steps.context.outputs.release_mode == 'deploy_only'
+        run: |
+          {
+            echo "SNAPSHOT_NAME=${SNAPSHOT_NAME}"
+            echo "DATAPREP_VERSION=${DATAPREP_VERSION}"
+            echo "DATA_VERSION=${DATA_VERSION}"
+          } >> "${GITHUB_ENV}"
+        env:
+          SNAPSHOT_NAME: ${{ steps.snapshot_tagged.outputs.snapshot_name }}
+          DATAPREP_VERSION: ${{ steps.snapshot_tagged.outputs.dataprep_version }}
+          DATA_VERSION: ${{ steps.snapshot_tagged.outputs.data_version }}
 
       - name: Deploy deces.matchid.io
         env:


### PR DESCRIPTION
## Scope
- make CI PR-only on main
- split deces-backend build/tests and keep artillery non-blocking
- allow manual dev redeploy with dataprep year only when required
- allow manual prod redeploy by tag without forcing full dataprep

## Notes
- no Makefile changes
- no image rebuild reintroduced in release-prod
- cd push/main path kept intact outside manual redeploy logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration pipeline with improved testing orchestration and better control flow during release processes.
  * Implemented flexible release modes providing granular control over deployment execution and data synchronization workflows.

* **Tests**
  * Added automated performance benchmarking integrated into the release pipeline to ensure application performance standards during deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->