### PR TITLE
fix: derive prod snapshot metadata without recheck

### DIFF
--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -235,17 +235,7 @@ jobs:
       - name: Capture prod snapshot metadata
         run: |
           set -euo pipefail
-          rm -f packages/deces-dataprep/repository-check
-          for attempt in $(seq 1 12); do
-            make -C packages/deces-dataprep repository-check GIT_BRANCH=master REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}"
-            if test -s packages/deces-dataprep/repository-check; then
-              break
-            fi
-            rm -f packages/deces-dataprep/repository-check
-            sleep 5
-          done
-          test -s packages/deces-dataprep/repository-check
-          SNAPSHOT_NAME=$(cat packages/deces-dataprep/repository-check)
+          SNAPSHOT_NAME=$(make artifact-version-dataprep-snapshot FILES_TO_PROCESS="${DATAPREP_FILES_TO_PROCESS_PROD}" REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}" | tail -1)
           DATAPREP_VERSION=$(echo "${SNAPSHOT_NAME}" | sed -E 's/^esdata_([^_]+)_.*/\1/')
           DATA_VERSION=$(echo "${SNAPSHOT_NAME}" | sed -E 's/^esdata_[^_]+_([^_]+)$/\1/')
           {

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -368,17 +368,7 @@ jobs:
         if: steps.context.outputs.release_mode == 'full_and_deploy' || (steps.context.outputs.release_mode == 'auto' && (steps.context.outputs.dataprep_changed == 'true' || steps.snapshot_auto.outputs.run_full == 'true'))
         run: |
           set -euo pipefail
-          rm -f packages/deces-dataprep/repository-check
-          for attempt in $(seq 1 12); do
-            make -C packages/deces-dataprep repository-check GIT_BRANCH=master REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}"
-            if test -s packages/deces-dataprep/repository-check; then
-              break
-            fi
-            rm -f packages/deces-dataprep/repository-check
-            sleep 5
-          done
-          test -s packages/deces-dataprep/repository-check
-          SNAPSHOT_NAME=$(cat packages/deces-dataprep/repository-check)
+          SNAPSHOT_NAME=$(make artifact-version-dataprep-snapshot FILES_TO_PROCESS="${DATAPREP_FILES_TO_PROCESS_PROD}" REPOSITORY_BUCKET="${PROD_REPOSITORY_BUCKET}" | tail -1)
           DATAPREP_VERSION=$(echo "${SNAPSHOT_NAME}" | sed -E 's/^esdata_([^_]+)_.*/\1/')
           DATA_VERSION=$(echo "${SNAPSHOT_NAME}" | sed -E 's/^esdata_[^_]+_([^_]+)$/\1/')
           {


### PR DESCRIPTION
## Scope
- remove repository recheck after successful prod full snapshot
- derive snapshot metadata deterministically from dataprep/data versions

## Root cause
release-prod full succeeded, but the follow-up repository-check on the runner did not see the new snapshot quickly enough, so the workflow failed before deploy.

## Fix
- after a successful full remote-all, compute snapshot_name from the deterministic version contract instead of polling repository-check again
- apply the same fix to dataprep-monthly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined internal deployment workflows to improve consistency and reduce release cycle time across production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->