### PR TITLE
fix: restore package artifact version contract

### DIFF
--- a/.github/workflows/dataprep-monthly.yml
+++ b/.github/workflows/dataprep-monthly.yml
@@ -111,6 +111,16 @@ jobs:
           fetch-depth: 0
           ref: ${{ steps.context.outputs.prod_tag }}
 
+      - name: Resolve published image versions
+        id: images
+        run: |
+          set -euo pipefail
+          {
+            echo "deces_ui_image_version=$(make artifact-version-deces-ui GIT_BRANCH=master | tail -1)"
+            echo "deces_backend_image_version=$(make artifact-version-deces-backend GIT_BRANCH=master | tail -1)"
+            echo "dataprep_backend_image_version=$(make artifact-version-dataprep-backend GIT_BRANCH=master | tail -1)"
+          } >> "${GITHUB_OUTPUT}"
+
       - name: Install deploy SSH key
         run: |
           test -n "${SSH_PRIVATE_KEY}"
@@ -215,11 +225,13 @@ jobs:
             SLACK_TITLE="deces-dataprep - monthly" SLACK_WEBHOOK="${SLACK_WEBHOOK}" \
             REMOTE_TOOLS_REPOSITORY=matchID REMOTE_TOOLS_BRANCH="${PROD_TAG}" REMOTE_TOOLS_PATH=matchID/matchID REMOTE_TOOLS_MAKE_PATH=matchID/matchID/packages/tools \
             REMOTE_APP_REPOSITORY=matchID REMOTE_APP_BRANCH="${PROD_TAG}" REMOTE_APP_PATH=matchID/matchID REMOTE_APP_MAKE_PATH=matchID/matchID/packages/deces-dataprep \
+            DATAPREP_BACKEND_MAKEOVERRIDES="APP_VERSION=${DATAPREP_BACKEND_IMAGE_VERSION}" \
             SSHKEY_PRIVATE="${HOME}/.ssh/id_rsa_matchID" \
             CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
         env:
           BASTION_HOST: ${{ secrets.BASTION_HOST || secrets.NGINX_HOST }}
           BASTION_USER: ${{ secrets.BASTION_USER || 'ubuntu' }}
+          DATAPREP_BACKEND_IMAGE_VERSION: ${{ steps.images.outputs.dataprep_backend_image_version }}
           PROD_TAG: ${{ steps.context.outputs.prod_tag }}
           remote_http_proxy: ${{ secrets.remote_http_proxy }}
           remote_https_proxy: ${{ secrets.remote_https_proxy }}
@@ -289,9 +301,13 @@ jobs:
           NEW_RELIC_ACCOUNT_ID: ${{ secrets.NEW_RELIC_ACCOUNT_ID }}
           MONITOR_BUCKET: ${{ secrets.MONITOR_BUCKET }}
           SSH_AUTH_SOCK: /tmp/ssh_agent.sock
+          DECES_UI_IMAGE_VERSION: ${{ steps.images.outputs.deces_ui_image_version }}
+          DECES_BACKEND_IMAGE_VERSION: ${{ steps.images.outputs.deces_backend_image_version }}
         run: |
           make deploy-remote-preflight \
             GIT_BRANCH=master \
+            APP_VERSION="${DECES_UI_IMAGE_VERSION}" \
+            DECES_BACKEND_APP_VERSION="${DECES_BACKEND_IMAGE_VERSION}" \
             GIT_BACKEND_BRANCH=master \
             REMOTE_DEPLOY_BRANCH="${PROD_TAG}" \
             DEPLOY_TARGET=prod \
@@ -303,6 +319,8 @@ jobs:
             CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
           make deploy-remote \
             GIT_BRANCH=master \
+            APP_VERSION="${DECES_UI_IMAGE_VERSION}" \
+            DECES_BACKEND_APP_VERSION="${DECES_BACKEND_IMAGE_VERSION}" \
             GIT_BACKEND_BRANCH=master \
             REMOTE_DEPLOY_BRANCH="${PROD_TAG}" \
             DEPLOY_TARGET=prod \

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -83,7 +83,6 @@ jobs:
           TAG_SHA=$(git rev-list -n 1 "${PROD_TAG}")
           git merge-base --is-ancestor "${TAG_SHA}" origin/main
           PREVIOUS_PROD_TAG=$(git tag --list 'v*' --sort=-creatordate | grep -Fxv "${PROD_TAG}" | head -n 1 || true)
-          COMMIT_SHORT=$(git rev-parse --short "${TAG_SHA}")
           DATAPREP_CHANGED=true
           if [ -n "${PREVIOUS_PROD_TAG}" ]; then
             if git diff --quiet "${PREVIOUS_PROD_TAG}" "${PROD_TAG}" -- \
@@ -100,7 +99,6 @@ jobs:
           {
             echo "prod_tag=${PROD_TAG}"
             echo "tag_sha=${TAG_SHA}"
-            echo "commit_short=${COMMIT_SHORT}"
             echo "previous_prod_tag=${PREVIOUS_PROD_TAG}"
             echo "dataprep_changed=${DATAPREP_CHANGED}"
             echo "release_mode=${RELEASE_MODE}"
@@ -221,8 +219,9 @@ jobs:
         id: images
         run: |
           set -euo pipefail
-          COMMIT_SHORT="${{ steps.context.outputs.commit_short }}"
           DATAPREP_BACKEND_IMAGE_VERSION=
+          DECES_UI_IMAGE_VERSION=$(make artifact-version-deces-ui GIT_BRANCH=master | tail -1)
+          DECES_BACKEND_IMAGE_VERSION=$(make artifact-version-deces-backend GIT_BRANCH=master | tail -1)
           RUN_FULL=false
           if [ "${{ steps.context.outputs.release_mode }}" = "full_and_deploy" ]; then
             RUN_FULL=true
@@ -230,12 +229,11 @@ jobs:
             RUN_FULL=true
           fi
           if [ "${RUN_FULL}" = "true" ]; then
-            CURRENT_DATAPREP_BACKEND_VERSION=$(make -s -C packages/dataprep-backend version GIT_BRANCH=master | awk '{print $NF}')
-            DATAPREP_BACKEND_IMAGE_VERSION="${COMMIT_SHORT}-${CURRENT_DATAPREP_BACKEND_VERSION##*-}"
+            DATAPREP_BACKEND_IMAGE_VERSION=$(make artifact-version-dataprep-backend GIT_BRANCH=master | tail -1)
           fi
           {
-            echo "deces_ui_image_version=${COMMIT_SHORT}"
-            echo "deces_backend_image_version=${COMMIT_SHORT}"
+            echo "deces_ui_image_version=${DECES_UI_IMAGE_VERSION}"
+            echo "deces_backend_image_version=${DECES_BACKEND_IMAGE_VERSION}"
             echo "dataprep_backend_image_version=${DATAPREP_BACKEND_IMAGE_VERSION}"
           } >> "${GITHUB_OUTPUT}"
 

--- a/Makefile
+++ b/Makefile
@@ -132,8 +132,8 @@ tag                 := $(shell printf '%s' "$(git_ref_raw)" | sed 's/-.*//' | se
 lastcommit          := $(shell touch .lastcommit && cat .lastcommit)
 date                := $(shell date -I)
 
-export APP_VERSION := $(git_ref_safe)
-export DECES_BACKEND_APP_VERSION ?= $(shell cd ${BACKEND_PATH} && (git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null) | sed 's#[^A-Za-z0-9_.-]#-#g')
+export APP_VERSION ?= $(shell env -u APP_VERSION -u MAKEFLAGS -u MFLAGS ${MAKEBIN} --no-print-directory -s -C ${FRONTEND_PATH} version 2>/dev/null | awk '{print $$NF}')
+export DECES_BACKEND_APP_VERSION ?= $(shell env -u APP_VERSION -u DECES_BACKEND_APP_VERSION -u MAKEFLAGS -u MFLAGS ${MAKEBIN} --no-print-directory -s -C ${BACKEND_PATH} version 2>/dev/null | awk '{print $$NF}')
 
 ifeq (${DEPLOY_TARGET},prod)
 export APP_DNS_TARGET ?= ${APP_DNS}
@@ -247,10 +247,10 @@ network: config
 
 
 backend-docker-check:
-	@${MAKE} docker-check DC_IMAGE_NAME=deces-backend APP_VERSION=${APP_VERSION} GIT_BRANCH=${GIT_BRANCH}
+	@${MAKE} docker-check DC_IMAGE_NAME=deces-backend APP_VERSION=${DECES_BACKEND_APP_VERSION} GIT_BRANCH=${GIT_BRANCH}
 
 backend: backend-docker-check proofs-mount elasticsearch-index-readiness
-	@${MAKE} -C ${BACKEND_PATH} backend-start APP=deces-backend DC_NETWORK=${DC_NETWORK} APP_VERSION=${APP_VERSION} GIT_BRANCH=${GIT_BRANCH}\
+	@${MAKE} -C ${BACKEND_PATH} backend-start APP=deces-backend DC_NETWORK=${DC_NETWORK} APP_VERSION=${DECES_BACKEND_APP_VERSION} GIT_BRANCH=${GIT_BRANCH}\
 		APP_URL=${APP_URL} API_EMAIL=${API_EMAIL} API_SSL=${API_SSL}\
 		BACKEND_JOB_CONCURRENCY=${BACKEND_JOB_CONCURRENCY} BACKEND_CHUNK_CONCURRENCY=${BACKEND_CHUNK_CONCURRENCY}\
 		BACKEND_TOKEN_USER=${BACKEND_TOKEN_USER} BACKEND_TOKEN_KEY=${BACKEND_TOKEN_KEY} BACKEND_TOKEN_PASSWORD=${BACKEND_TOKEN_PASSWORD}\
@@ -356,10 +356,10 @@ artifact-version-dataprep-frontend:
 	@${MAKE} -C ${APP_PATH}/packages/dataprep-frontend version | awk '{print $$NF}'
 
 artifact-version-deces-backend:
-	@echo ${APP_VERSION}
+	@env -u APP_VERSION -u DECES_BACKEND_APP_VERSION -u MAKEFLAGS -u MFLAGS ${MAKEBIN} --no-print-directory -s -C ${BACKEND_PATH} version | awk '{print $$NF}'
 
 artifact-version-deces-ui:
-	@echo ${APP_VERSION}
+	@env -u APP_VERSION -u MAKEFLAGS -u MFLAGS ${MAKEBIN} --no-print-directory -s -C ${FRONTEND_PATH} version | awk '{print $$NF}'
 
 artifact-version-dataprep-snapshot: ${DATAPREP_VERSION_FILE} ${DATA_VERSION_FILE}
 	@echo esdata_$$(cat ${DATAPREP_VERSION_FILE})_$$(cat ${DATA_VERSION_FILE})
@@ -428,7 +428,7 @@ show-env:
 		fi; \
 	done
 
-deploy-local: config show-env stats-background elasticsearch-restore-async docker-login docker-check up local-test-api
+deploy-local: config show-env stats-background elasticsearch-restore-async docker-login frontend-docker-check up local-test-api
 
 # smtp:
 # 	@${MAKE} -C ${BACKEND_PATH} smtp DC_NETWORK=${DC_NETWORK}

--- a/PLAN.md
+++ b/PLAN.md
@@ -350,6 +350,8 @@
     - [x] Introduire une source de version semantique dediee pour `packages/dataprep-backend` hors `changesets`
       - [x] Ajouter `packages/dataprep-backend/VERSION` avec la base semantique courante `0.4.0`
       - [x] Faire porter la version finale par `packages/dataprep-backend/VERSION` dans la PR mergee sur `main`
+    - [x] Realigner le contrat de version d'artefact sur l'upstream: format `tag-VERSION`, `tag` issu de `package.json` ou `VERSION`, hash `tagfiles.version` conserve
+    - [x] Supprimer la dependance entre tag Git prod `v*` et resolution des versions d'images dans `release-prod.yml` et `dataprep-monthly.yml`
     - [ ] Reconfigurer la gouvernance GitHub pour `main` et pour les tags proteges, en supprimant les protections `master`
     - [ ] Refondre `ci.yml` et `cd.yml` vers le cycle `pull_request -> main`, `push -> main`, `push tag v*` et `schedule/workflow_dispatch` dataprep mensuel
       - [x] Basculer `ci.yml` sur `pull_request -> main` et `push -> main`
@@ -374,6 +376,11 @@
     - [ ] Prouver qu'un merge sur `main` deploie bien `dev-deces.matchid.io`
     - [ ] Prouver qu'un tag manuel `v*` sur `main` deploie bien la prod
     - [ ] Prouver que le dataprep mensuel resolve le dernier tag prod, produit un snapshot `full` et redeploie automatiquement la prod avec ce tag
+    - [x] Verifier localement les versions d'artefacts attendues via `make artifact-version-*`:
+      - [x] `deces-ui` -> `0.4.0-0f7395`
+      - [x] `deces-backend` -> `1.0.0-d36bd4`
+      - [x] `dataprep-backend` -> `0.4.0-e4d91b`
+      - [x] `dataprep-frontend` -> `1.0.1-2d96b8`
     - [ ] Prouver qu'un merge sur `main` publie `dev-deces.matchid.io` via le switch nginx actuel
     - [ ] Prouver qu'un tag `v*` publie `deces.matchid.io` via le switch nginx actuel
     - [ ] Prouver qu'un echec du dataprep mensuel emet une alerte sans retry automatique

--- a/packages/dataprep-backend/Makefile
+++ b/packages/dataprep-backend/Makefile
@@ -106,7 +106,7 @@ export SERVICES=${DB_SERVICES} backend frontend
 dummy		    := $(shell touch artifacts)
 include ./artifacts
 
-tag                 := $(shell [ -f "/usr/bin/git" ] && ((git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null) | sed 's/-.*//' | sed 's#[^A-Za-z0-9_.-]#-#g'))
+tag                 := $(shell tr -d '\r\n[:space:]' < ${APP_PATH}/VERSION)
 version 			:= $(shell export LC_COLLATE=C;export LC_ALL=C;cat tagfiles.version | xargs -I '{}' find {} -type f | egrep -v 'conf/security/(github|facebook|twitter).yml$$|.tar.gz$$|.pyc$$|.gitignore$$' | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')
 export APP_VERSION =  ${tag}-${version}
 

--- a/packages/dataprep-frontend/Makefile
+++ b/packages/dataprep-frontend/Makefile
@@ -56,7 +56,7 @@ export BACKEND_DC_IMAGE_NAME=${DC_PREFIX}-${GIT_BACKEND}
 dummy		    := $(shell touch artifacts)
 include ./artifacts
 
-tag                 := $(shell [ -f "/usr/bin/git" ] && ((git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null) | sed 's/-.*//' | sed 's#[^A-Za-z0-9_.-]#-#g'))
+tag                 := $(shell sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' ${FRONTEND}/package.json | head -n 1)
 version 			:= $(shell export LC_COLLOCATE=C;export LC_ALL=C;cat tagfiles.version | xargs -I '{}' find {} -type f -not -name '*.tar.gz'  | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')
 export APP_VERSION =  ${tag}-${version}
 

--- a/packages/deces-backend/Makefile
+++ b/packages/deces-backend/Makefile
@@ -10,7 +10,6 @@ export MONOREPO_ROOT ?= $(abspath ${BACKEND_PATH}/../..)
 # Canonical tools live in the sibling monorepo package, not in a local backend/tools clone.
 export TOOLS_PATH ?= $(abspath ${BACKEND_PATH}/../tools)
 export APP_DNS?=deces.matchid.io
-export APP_VERSION	:= $(shell (git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null) | sed 's#[^A-Za-z0-9_.-]#-#g')
 export USE_TTY := $(shell test -t 1 && USE_TTY="-t")
 
 # make options
@@ -106,9 +105,19 @@ export SCW_ENDPOINT?=s3.fr-par.scw.cloud
 dummy		    := $(shell touch artifacts)
 include ./artifacts
 
+package_tag := $(shell sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' ${BACKEND_PATH}/package.json | head -n 1)
+version_hash := $(shell cd ${BACKEND_PATH} && export LC_COLLATE=C; export LC_ALL=C; cat tagfiles.version | xargs -I '{}' find {} -type f | egrep -v '.tar.gz$$|.pyc$$|.gitignore$$' | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')
+export APP_VERSION ?= ${package_tag}-${version_hash}
+
 ifeq ($(abspath $(CURDIR)),$(abspath $(BACKEND_PATH)))
 config:
 	@${MAKE} -C ${TOOLS_PATH} config
+
+version:
+	@echo ${APP_GROUP} ${APP} ${APP_VERSION}
+
+version-files:
+	@cd ${BACKEND_PATH} && export LC_COLLATE=C; export LC_ALL=C; cat tagfiles.version | xargs -I '{}' find {} -type f | egrep -v '.tar.gz$$|.pyc$$|.gitignore$$' | sort
 endif
 
 

--- a/packages/deces-backend/tagfiles.version
+++ b/packages/deces-backend/tagfiles.version
@@ -1,0 +1,11 @@
+src
+docker-compose.yml
+docker-compose-dev-backend.yml
+docker-compose-smtp.yml
+Dockerfile
+eslint.config.mjs
+package.json
+package-lock.json
+tsconfig.json
+tsconfig.tsoa.json
+tagfiles.version

--- a/packages/deces-ui/Makefile
+++ b/packages/deces-ui/Makefile
@@ -1,6 +1,9 @@
 # Makefile for deces-ui
 # Frontend and nginx services management
 
+export FRONTEND_PATH ?= $(shell pwd)
+export APP_FRONTEND ?= deces-ui
+
 # Frontend basic configuration variables
 export FRONTEND = ${FRONTEND_PATH}
 export FRONTEND_DEV_HOST = frontend-development
@@ -19,6 +22,10 @@ export BUILD_DIR=${APP_PATH}/${APP_FRONTEND}-build
 export FILE_FRONTEND_APP_VERSION = $(APP)-$(APP_VERSION)-frontend.tar.gz
 export FILE_FRONTEND_DIST_APP_VERSION = $(APP)-$(APP_VERSION)-frontend-dist.tar.gz
 export FILE_FRONTEND_DIST_LATEST_VERSION = $(APP)-latest-frontend-dist.tar.gz
+
+package_tag := $(shell sed -n 's/.*"version"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' ${FRONTEND_PATH}/package.json | head -n 1)
+version_hash := $(shell cd ${FRONTEND_PATH} && cat tagfiles.version | xargs -I '{}' find {} -type f -not -name '*.tar.gz' | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')
+export APP_VERSION ?= ${package_tag}-${version_hash}
 
 # Test configuration variables
 export TEST_HOST=nginx
@@ -59,6 +66,14 @@ export NPM_AUDIT_IGNORE?=true
 
 # A/B testing configuration variables
 export AB_THRESHOLD=100
+
+ifeq ($(abspath $(CURDIR)),$(abspath $(FRONTEND_PATH)))
+version:
+	@echo ${APP_VERSION}
+
+version-files:
+	@cd ${FRONTEND_PATH} && cat tagfiles.version | xargs -I '{}' find {} -type f -not -name '*.tar.gz' | sort
+endif
 
 # Frontend targets
 frontend-update:

--- a/packages/deces-ui/package-lock.json
+++ b/packages/deces-ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "deces-ui",
-  "version": "0.1.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "deces-ui",
-      "version": "0.1.2",
+      "version": "0.4.0",
       "devDependencies": {
         "@beyonk/svelte-google-analytics": "^2.6.4",
         "@rollup/plugin-commonjs": "=21.0.2",

--- a/packages/deces-ui/package.json
+++ b/packages/deces-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deces-ui",
-  "version": "0.1.2",
+  "version": "0.4.0",
   "scripts": {
     "build": "rollup -c",
     "dev": "rollup -c -w",

--- a/packages/deces-ui/tagfiles.version
+++ b/packages/deces-ui/tagfiles.version
@@ -1,6 +1,6 @@
 docker-compose-build.yml
 docker-compose-dev.yml
-docker-compose-elasticsearch.yml
+docker-compose-test.yml
 docker-compose.yml
 Dockerfile
 Makefile

--- a/spec/SPEC_EVOL_010_VERSIONNING_RELEASE_MAIN_TAG.md
+++ b/spec/SPEC_EVOL_010_VERSIONNING_RELEASE_MAIN_TAG.md
@@ -171,6 +171,29 @@ Regles:
   il doit rester encapsule derriere `make` et ne pas changer le contrat
   operatoire.
 
+### Version d'artefact Docker
+
+Les tags d'images applicatives conservent le contrat historique:
+
+```text
+tag-VERSION
+```
+
+Regles:
+
+- `tag` ne vient plus de `git describe --tags`;
+- `tag` vient de la version semantique du package:
+  - `package.json` pour `deces-ui`, `deces-backend`, `dataprep-frontend`;
+  - `VERSION` pour `dataprep-backend`;
+- `VERSION` conserve la logique actuelle de hash des fichiers listes dans
+  `tagfiles.version`;
+- un changement hors des fichiers de `tagfiles.version` ne doit pas changer le
+  tag Docker publie;
+- le tag Git de release prod `v*` ne doit jamais participer au calcul du nom
+  des images;
+- `release-prod.yml` et `dataprep-monthly.yml` consomment uniquement les cibles
+  `make artifact-version-*`.
+
 ### Package Python `dataprep-backend`
 
 `dataprep-backend` suit un versionning independant, mais hors `changesets`.
@@ -242,6 +265,7 @@ Regles:
 - il est cree manuellement apres validation UAT smoke sur
   `dev-deces.matchid.io`, via GitHub ou sur demande explicite;
 - il declenche la release prod;
+- il ne versionne pas les images Docker;
 - il reference implicitement les versions package presentes dans le commit
   pointe;
 - il devient la reference de `APP_RELEASE` pour la prod;


### PR DESCRIPTION
## Summary
- restore package-level artifact versioning as  with  from  or 
- stop using the prod Git tag as an image-version source in  and 
- document the artifact-version contract and validate the expected  outputs

## Verification
- 0.4.0-0f7395
- 1.0.0-d36bd4
- 0.4.0-e4d91b
- 1.0.1-2d96b8
- 0.4.0
- 1.0.0
- 1.0.1
- 0.4.0
- yaml-ok
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Transitioned versioning system from Git-derived to package-based version resolution for more predictable and maintainable releases.
  * Updated deployment workflows to use standardized artifact versioning via Makefile targets.

* **Chores**
  * Bumped deces-ui version to 0.4.0.
  * Documented Docker artifact versioning specification and tagging conventions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->