### PR TITLE
fix: realign remote dataprep execution

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -514,17 +514,7 @@ jobs:
       - name: Export dataprep year snapshot metadata
         if: steps.year_context.outputs.should_run == 'true'
         run: |
-          rm -f packages/deces-dataprep/repository-check
-          for attempt in $(seq 1 12); do
-            make -C packages/deces-dataprep repository-check GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
-            if test -s packages/deces-dataprep/repository-check; then
-              break
-            fi
-            rm -f packages/deces-dataprep/repository-check
-            sleep 5
-          done
-          test -s packages/deces-dataprep/repository-check
-          SNAPSHOT_NAME=$(cat packages/deces-dataprep/repository-check)
+          SNAPSHOT_NAME=$(make artifact-version-dataprep-snapshot FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}" | tail -1)
           {
             echo "snapshot_name=${SNAPSHOT_NAME}"
             echo "repository_bucket=${REPOSITORY_BUCKET}"

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ log-db
 .env.development.local
 .env.test.local
 .env.production.local
+.codex-runs
+.playwright-mcp

--- a/Makefile
+++ b/Makefile
@@ -405,8 +405,6 @@ artifact-produce-dataprep-snapshot:
 	@${MAKE} -C ${DATAPREP_PATH} config ${MAKEOVERRIDES}
 	@${MAKE} -C ${APP_PATH}/packages/dataprep-backend backend-build ${MAKEOVERRIDES}
 	@${MAKE} dataprep-run \
-		DATAPREP_BACKEND_LOCAL_TARGET=backend \
-		DATAPREP_BACKEND_LOCAL_STOP_TARGET=backend-stop \
 		RECIPE_RUN_MARKER=${ARTIFACT_RECIPE_RUN_MARKER} \
 		S3_PULL_MARKER=${ARTIFACT_S3_PULL_MARKER} \
 		${MAKEOVERRIDES}

--- a/packages/dataprep-backend/Makefile
+++ b/packages/dataprep-backend/Makefile
@@ -61,9 +61,6 @@ export GIT_FRONTEND_BRANCH ?= ${GIT_BRANCH}
 
 export FRONTEND=${BACKEND}/../${GIT_FRONTEND}
 export FRONTEND_DC_IMAGE_NAME=${DC_PREFIX}-${GIT_FRONTEND}
-export BACKEND_RUN_TARGET ?= backend
-export BACKEND_RUN_CONTAINER ?=
-
 export API_SECRET_KEY:=$(shell openssl rand -base64 24)
 export ADMIN_PASSWORD:=$(shell openssl rand -base64 24)
 export ADMIN_PASSWORD_HASH:=$(shell echo -n ${ADMIN_PASSWORD} | sha384sum | sed 's/\s*\-.*//')
@@ -654,18 +651,8 @@ example-download:
 	@ln -s ${EXAMPLES}/projects ${BACKEND}/projects
 	@ln -s ${EXAMPLES}/data ${BACKEND}/upload
 
-recipe-run: ${BACKEND_RUN_TARGET}
-	@BACKEND_CONTAINER="${BACKEND_RUN_CONTAINER}";\
-	if [ -z "$$BACKEND_CONTAINER" ]; then\
-		if [ "${BACKEND_RUN_TARGET}" = "backend-dev" ]; then\
-			BACKEND_CONTAINER="${DC_PREFIX}-backend-dev";\
-		else\
-			BACKEND_CONTAINER="${DC_PREFIX}-backend";\
-		fi;\
-	fi;\
-	docker exec -i ${USE_TTY} $$BACKEND_CONTAINER sh -lc "cd /${APP_GROUP} && mkdir -p /${APP_GROUP}/log && PYTHONPATH=/${APP_GROUP}/code nohup python -c 'import config; config.init(); config.read_conf(); from log import Log; from recipes import Recipe; config.log = Log(\"main\"); r = Recipe(\"${RECIPE}\"); r.init(); r.run()' >/${APP_GROUP}/log/${RECIPE}.log 2>&1 &" \
-	&& echo "{\"recipe\":\"${RECIPE}\",\"status\":\"new job\"}" \
-	&& echo ${RECIPE} run
+recipe-run: backend
+	docker exec -i ${USE_TTY} ${DC_PREFIX}-backend curl -s -XPUT http://localhost:${PORT}/matchID/api/v0/recipes/${RECIPE}/run && echo ${RECIPE} run
 
 deploy-local: config up local-test-api
 

--- a/packages/deces-dataprep/.gitignore
+++ b/packages/deces-dataprep/.gitignore
@@ -6,4 +6,10 @@ data
 scw.id
 s3.tag
 ec2.id
-
+check-s3
+datagouv-to-s3
+datagouv-to-storage
+recipe-run
+repository-check
+repository-config
+s3-pull

--- a/packages/deces-dataprep/Makefile
+++ b/packages/deces-dataprep/Makefile
@@ -37,12 +37,7 @@ export REPOSITORY_BUCKET ?= ${DATAGOUV_DATASET}-elasticsearch
 export DATA_DIR=${PWD}/data
 export DATAPREP_BACKEND_PATH=${MONOREPO_ROOT}/packages/dataprep-backend
 export DATAPREP_FRONTEND_PATH=${MONOREPO_ROOT}/packages/dataprep-frontend
-export DATAPREP_BACKEND_LOCAL_TARGET ?= backend-dev
-export DATAPREP_BACKEND_LOCAL_STOP_TARGET ?= backend-dev-stop
 export DATAPREP_BACKEND_DEPLOY_TARGET ?= backend
-export DATAPREP_BACKEND_RUN_CONTAINER ?=
-export DATAPREP_BACKEND_PORT ?= 8080
-export DATAPREP_BACKEND_TIMEOUT ?= 60
 export BACKUP_DIR = ${DATAPREP_BACKEND_PATH}/backup
 export DATA_TAG=${MONOREPO_ROOT}/.data.sha1
 export BACKUP_METHOD=repository
@@ -78,7 +73,7 @@ export SCW_VOLUME_SIZE=50000000000
 export SCW_IMAGE_ID=8e7f9833-9787-4488-aea7-819183132acc
 export MONOREPO_TOOLS_PATH=${APP_PATH}/../tools
 export MONOREPO_ROOT=${APP_PATH}/../..
-DATAPREP_BACKEND_MAKEOVERRIDES := $(filter-out APP=%,$(MAKEOVERRIDES))
+DATAPREP_BACKEND_MAKEOVERRIDES := $(filter-out APP=% APP_VERSION=%,$(MAKEOVERRIDES))
 export INFRA_PATH=${MONOREPO_ROOT}/packages/deces-infra
 export FRONTEND_PATH=${DATAPREP_FRONTEND_PATH}
 
@@ -212,14 +207,14 @@ backup-pull: data-tag
 	touch backup-pull
 
 dev: config monorepo-elasticsearch frontend-config
-	@${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend &&\
+	@${MAKE} -C ${DATAPREP_BACKEND_PATH} backend-dev ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend &&\
 	${MAKE} -C ${FRONTEND_PATH} frontend-dev GIT_BRANCH=${GIT_FRONTEND_BRANCH} NPM_AUDIT_IGNORE=true ${MAKEOVERRIDES} &&\
 		echo matchID started, go to http://localhost:8081
 
 dev-stop:
 	@if [ -f config ]; then\
 		if [ -d "${FRONTEND_PATH}" ]; then ${MAKE} -C ${FRONTEND_PATH} frontend-dev-stop ${MAKEOVERRIDES}; fi;\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
+		${MAKE} -C ${DATAPREP_BACKEND_PATH} backend-dev-stop ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
 		${MAKE} monorepo-elasticsearch-stop ${MAKEOVERRIDES};\
 	fi
 
@@ -229,54 +224,21 @@ up:
 	${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_DEPLOY_TARGET} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend && echo matchID backend services started
 
 dataprep-backend-recipe-run:
-	@if grep -q 'BACKEND_RUN_TARGET ?=' ${DATAPREP_BACKEND_PATH}/Makefile; then\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} recipe-run \
-			ES_HOST=${ES_HOST} \
-			BACKEND_RUN_TARGET=${DATAPREP_BACKEND_LOCAL_TARGET} \
-			BACKEND_RUN_CONTAINER=${DATAPREP_BACKEND_RUN_CONTAINER} \
-			CHUNK_SIZE=${CHUNK_SIZE} RECIPE=${RECIPE} RECIPE_THREADS=${RECIPE_THREADS} RECIPE_QUEUE=${RECIPE_QUEUE} \
-			ES_PRELOAD='${ES_PRELOAD}' ES_THREADS=${ES_THREADS} \
-			STORAGE_BUCKET=${STORAGE_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}\
-			${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
-	else\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_TARGET} ES_HOST=${ES_HOST} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
-		BACKEND_CONTAINER="${DATAPREP_BACKEND_RUN_CONTAINER}";\
-		if [ -z "$$BACKEND_CONTAINER" ]; then\
-			if [ "${DATAPREP_BACKEND_LOCAL_TARGET}" = "backend-dev" ]; then\
-				BACKEND_CONTAINER="matchid-backend-dev";\
-			else\
-				BACKEND_CONTAINER="matchid-backend";\
-			fi;\
-		fi;\
-		timeout=${DATAPREP_BACKEND_TIMEOUT}; ret=1;\
-		until [ "$$timeout" -le 0 -o "$$ret" -eq "0" ] ; do\
-			(docker exec -i ${USE_TTY} $$BACKEND_CONTAINER curl -s --noproxy "*" --fail -XGET localhost:${DATAPREP_BACKEND_PORT}/matchID/api/v0/ > /dev/null) ;\
-			ret=$$? ;\
-			if [ "$$ret" -ne "0" ] ; then echo -en "\rwaiting for legacy dataprep backend to start $$timeout" ; fi ;\
-			((timeout--)); sleep 1 ;\
-		done ; echo ;\
-		if [ "$$ret" -ne "0" ]; then exit $$ret; fi;\
-		docker exec -i ${USE_TTY} $$BACKEND_CONTAINER sh -lc "cd /${APP_GROUP} && mkdir -p /${APP_GROUP}/log && PYTHONPATH=/${APP_GROUP}/code nohup python -c 'import config; config.init(); config.read_conf(); from log import Log; from recipes import Recipe; config.log = Log(\"main\"); r = Recipe(\"${RECIPE}\"); r.init(); r.run()' >/${APP_GROUP}/log/${RECIPE}.log 2>&1 &" \
-			&& echo "{\"recipe\":\"${RECIPE}\",\"status\":\"new job\"}" \
-			&& echo ${RECIPE} run;\
-	fi
+	@env -u APP_VERSION -u MAKEFLAGS -u MFLAGS ${MAKE} -C ${DATAPREP_BACKEND_PATH} recipe-run \
+		ES_HOST=${ES_HOST} \
+		CHUNK_SIZE=${CHUNK_SIZE} RECIPE=${RECIPE} RECIPE_THREADS=${RECIPE_THREADS} RECIPE_QUEUE=${RECIPE_QUEUE} \
+		ES_PRELOAD='${ES_PRELOAD}' ES_THREADS=${ES_THREADS} \
+		STORAGE_BUCKET=${STORAGE_BUCKET} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY} \
+		${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend
 
 dataprep-backend-logs:
-	@BACKEND_CONTAINER="${DATAPREP_BACKEND_RUN_CONTAINER}";\
-	if [ -z "$$BACKEND_CONTAINER" ]; then\
-		if [ "${DATAPREP_BACKEND_LOCAL_TARGET}" = "backend-dev" ]; then\
-			BACKEND_CONTAINER="matchid-backend-dev";\
-		else\
-			BACKEND_CONTAINER="matchid-backend";\
-		fi;\
-	fi;\
-	docker logs --tail=200 $$BACKEND_CONTAINER
+	@(docker logs --tail=200 matchid-backend 2>/dev/null || docker logs --tail=200 matchid-backend-dev)
 
 recipe-run-local: data-tag
 	@if [ ! -f "${RECIPE_RUN_MARKER}" ];then\
 		mkdir -p $$(dirname "${RECIPE_RUN_MARKER}") $$(dirname "${S3_PULL_MARKER}");\
 		echo running recipe on data FILES_TO_PROCESS="${FILES_TO_PROCESS}" $$(cat ${DATA_TAG}), dataprep ${DATAPREP_VERSION};\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} version APP=backend;\
+		env -u APP_VERSION -u MAKEFLAGS -u MFLAGS ${MAKE} -C ${DATAPREP_BACKEND_PATH} version APP=backend;\
 		${MAKE} dataprep-backend-recipe-run ${MAKEOVERRIDES} \
 			&&\
 		touch "${RECIPE_RUN_MARKER}" "${S3_PULL_MARKER}" &&\
@@ -417,7 +379,8 @@ respository-cleanse:
 down:
 	@if [ -f config ]; then\
 		if [ -d "${FRONTEND_PATH}" ]; then ${MAKE} -C ${FRONTEND_PATH} frontend-dev-stop ${MAKEOVERRIDES}; fi;\
-		${MAKE} -C ${DATAPREP_BACKEND_PATH} ${DATAPREP_BACKEND_LOCAL_STOP_TARGET} ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend;\
+		(${MAKE} -C ${DATAPREP_BACKEND_PATH} backend-stop ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend || true);\
+		(${MAKE} -C ${DATAPREP_BACKEND_PATH} backend-dev-stop ${DATAPREP_BACKEND_MAKEOVERRIDES} APP=backend || true);\
 		${MAKE} monorepo-elasticsearch-stop ${MAKEOVERRIDES};\
 	fi
 


### PR DESCRIPTION
## Summary
- realign remote dataprep recipe execution with the backend API flow
- stop leaking dataprep APP_VERSION into matchid-backend resolution
- export year snapshot metadata deterministically after a successful remote run

## Validation
- workflow_dispatch branch validation on dataprep year succeeded
- true reruns now use the backend image path instead of backend-dev rebuilds


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified and streamlined build and deployment infrastructure.
  * Improved recipe execution handling for enhanced reliability.
  * Removed legacy configuration overrides to reduce complexity.
  * Optimized backend startup and logging processes for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->