### PR TITLE
ci: align artifact invalidation and workflow DAGs

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,107 +38,139 @@ jobs:
     permissions:
       contents: read
     outputs:
-      dataprep_backend: ${{ steps.filter.outputs.dataprep_backend }}
-      dataprep_frontend: ${{ steps.filter.outputs.dataprep_frontend }}
-      deces_backend: ${{ steps.filter.outputs.deces_backend }}
-      deces_ui_app: ${{ steps.filter.outputs.deces_ui_app }}
-      deces_ui: ${{ steps.filter.outputs.deces_ui }}
-      dataprep_snapshot: ${{ steps.filter.outputs.dataprep_snapshot }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
-        with:
-          filters: |
-            dataprep_backend:
-              - 'Makefile'
-              - 'packages/dataprep-backend/**'
-              - 'packages/tools/**'
-              - '.github/workflows/cd.yml'
-            dataprep_frontend:
-              - 'Makefile'
-              - 'packages/dataprep-frontend/**'
-              - 'packages/tools/**'
-              - '.github/workflows/cd.yml'
-            deces_backend:
-              - 'Makefile'
-              - 'packages/deces-backend/**'
-              - 'packages/deces-infra/**'
-              - 'packages/tools/**'
-              - '.github/workflows/cd.yml'
-            deces_ui_app:
-              - 'packages/deces-ui/**'
-            deces_ui:
-              - 'Makefile'
-              - 'packages/deces-ui/**'
-              - 'packages/deces-backend/**'
-              - 'packages/deces-infra/**'
-              - 'packages/tools/**'
-              - '.github/workflows/cd.yml'
-            dataprep_snapshot:
-              - 'Makefile'
-              - 'packages/deces-dataprep/**'
-              - 'packages/dataprep-backend/**'
-              - 'packages/deces-infra/**'
-              - 'packages/tools/**'
-              - 'scripts/**'
-              - '.github/workflows/cd.yml'
-
-  dataprep-backend:
-    name: Publish matchid-backend image
-    needs: changes
-    if: >-
-      ${{
-        (
-          github.event_name == 'workflow_dispatch' &&
-          inputs.dataprep_scope == 'all'
-        ) ||
-        (
-          github.event_name == 'push' &&
-          needs.changes.outputs.dataprep_backend == 'true'
-        )
-      }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
+      artifact_matchid_backend: ${{ steps.detect.outputs.artifact_matchid_backend }}
+      artifact_matchid_frontend: ${{ steps.detect.outputs.artifact_matchid_frontend }}
+      artifact_deces_backend: ${{ steps.detect.outputs.artifact_deces_backend }}
+      artifact_deces_ui: ${{ steps.detect.outputs.artifact_deces_ui }}
+      artifact_dataprep_snapshot: ${{ steps.detect.outputs.artifact_dataprep_snapshot }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref || github.ref }}
+          fetch-depth: 0
+      - name: Resolve artifact flags
+        id: detect
+        run: |
+          set -euo pipefail
+
+          if [ "${GITHUB_EVENT_NAME}" = "push" ] && [ -n "${EVENT_BEFORE}" ]; then
+            git diff --name-only "${EVENT_BEFORE}" "${GITHUB_SHA}" | LC_ALL=C sort -u > /tmp/changed-files.txt
+          else
+            : > /tmp/changed-files.txt
+          fi
+          touch /tmp/changed-files.txt
+
+          prefixed_version_files() {
+            local dir="$1"
+            make -s -C "${dir}" version-files | sed "s#^#${dir}/#" | LC_ALL=C sort -u
+          }
+
+          emit_flag() {
+            echo "$1=$2" >> "${GITHUB_OUTPUT}"
+          }
+
+          resolve_artifact_flag() {
+            local name="$1"
+            local dir="$2"
+            local files="/tmp/${name}.files"
+            prefixed_version_files "${dir}" > "${files}"
+            if grep -Fxf "${files}" /tmp/changed-files.txt > /dev/null 2>&1; then
+              emit_flag "${name}" true
+            else
+              emit_flag "${name}" false
+            fi
+          }
+
+          resolve_artifact_flag artifact_matchid_backend packages/dataprep-backend
+          resolve_artifact_flag artifact_matchid_frontend packages/dataprep-frontend
+          resolve_artifact_flag artifact_deces_backend packages/deces-backend
+          resolve_artifact_flag artifact_deces_ui packages/deces-ui
+          resolve_artifact_flag artifact_dataprep_snapshot packages/deces-dataprep
+        env:
+          EVENT_BEFORE: ${{ github.event.before }}
+
+  ensure-matchid-backend-image:
+    name: ensure-matchid-backend-image
+    needs: changes
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      should_publish: ${{ steps.resolve.outputs.should_publish }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.client_payload.ref || github.ref }}
+      - name: Resolve matchid-backend execution
+        id: resolve
+        run: |
+          SHOULD_PUBLISH=false
+          REASON=unchanged
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${INPUT_DATAPREP_SCOPE}" = "all" ]; then
+            SHOULD_PUBLISH=true
+            REASON=explicit_all_dispatch
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${ARTIFACT_CHANGED}" = "true" ]; then
+            SHOULD_PUBLISH=true
+            REASON=artifact_changed
+          fi
+          {
+            echo "should_publish=${SHOULD_PUBLISH}"
+            echo "reason=${REASON}"
+          } >> "${GITHUB_OUTPUT}"
+        env:
+          INPUT_DATAPREP_SCOPE: ${{ inputs.dataprep_scope || 'none' }}
+          ARTIFACT_CHANGED: ${{ needs.changes.outputs.artifact_matchid_backend }}
       - name: Build matchid-backend image
+        if: steps.resolve.outputs.should_publish == 'true'
         run: |
           make -C packages/deces-dataprep config GIT_BRANCH=dev
           make -C packages/dataprep-backend backend-build GIT_BRANCH=dev
         env:
           CD_GIT_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
       - name: Publish matchid-backend image
+        if: steps.resolve.outputs.should_publish == 'true'
         run: make -C packages/dataprep-backend backend-docker-push GIT_BRANCH=dev
         env:
           CD_GIT_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: No-op matchid-backend image
+        if: steps.resolve.outputs.should_publish != 'true'
+        run: echo "No publish needed for matchid-backend (${{
+          steps.resolve.outputs.reason }})"
 
-  dataprep-frontend:
-    name: Publish matchid-frontend image
+  ensure-matchid-frontend-image:
+    name: ensure-matchid-frontend-image
     needs: changes
-    if: >-
-      ${{
-        (
-          github.event_name == 'workflow_dispatch' &&
-          inputs.dataprep_scope == 'all'
-        ) ||
-        (
-          github.event_name == 'push' &&
-          needs.changes.outputs.dataprep_frontend == 'true'
-        )
-      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      should_publish: ${{ steps.resolve.outputs.should_publish }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref || github.ref }}
+      - name: Resolve matchid-frontend execution
+        id: resolve
+        run: |
+          SHOULD_PUBLISH=false
+          REASON=unchanged
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${INPUT_DATAPREP_SCOPE}" = "all" ]; then
+            SHOULD_PUBLISH=true
+            REASON=explicit_all_dispatch
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${ARTIFACT_CHANGED}" = "true" ]; then
+            SHOULD_PUBLISH=true
+            REASON=artifact_changed
+          fi
+          {
+            echo "should_publish=${SHOULD_PUBLISH}"
+            echo "reason=${REASON}"
+          } >> "${GITHUB_OUTPUT}"
+        env:
+          INPUT_DATAPREP_SCOPE: ${{ inputs.dataprep_scope || 'none' }}
+          ARTIFACT_CHANGED: ${{ needs.changes.outputs.artifact_matchid_frontend }}
       - name: Build matchid-frontend image
+        if: steps.resolve.outputs.should_publish == 'true'
         run: |
           make -C packages/deces-dataprep config frontend-config GIT_BRANCH=dev
           make -C packages/dataprep-frontend build GIT_BRANCH=dev GIT_BACKEND_BRANCH=dev
@@ -146,94 +178,115 @@ jobs:
           CD_GIT_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
           NPM_AUDIT_IGNORE: "true"
       - name: Publish matchid-frontend image
+        if: steps.resolve.outputs.should_publish == 'true'
         run: make -C packages/dataprep-frontend frontend-docker-push GIT_BRANCH=dev GIT_BACKEND_BRANCH=dev
         env:
           CD_GIT_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: No-op matchid-frontend image
+        if: steps.resolve.outputs.should_publish != 'true'
+        run: echo "No publish needed for matchid-frontend (${{
+          steps.resolve.outputs.reason }})"
 
-  deces-backend:
-    name: Publish deces-backend image
+  ensure-deces-backend-image:
+    name: ensure-deces-backend-image
     needs: changes
-    if: >-
-      ${{
-        (
-          github.event_name == 'workflow_dispatch' &&
-          inputs.dataprep_scope == 'all'
-        ) ||
-        (
-          github.event_name == 'push' &&
-          needs.changes.outputs.deces_backend == 'true'
-        )
-      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      should_publish: ${{ steps.resolve.outputs.should_publish }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref || github.ref }}
+      - name: Resolve deces-backend execution
+        id: resolve
+        run: |
+          SHOULD_PUBLISH=false
+          REASON=unchanged
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${INPUT_DATAPREP_SCOPE}" = "all" ]; then
+            SHOULD_PUBLISH=true
+            REASON=explicit_all_dispatch
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${ARTIFACT_CHANGED}" = "true" ]; then
+            SHOULD_PUBLISH=true
+            REASON=artifact_changed
+          fi
+          {
+            echo "should_publish=${SHOULD_PUBLISH}"
+            echo "reason=${REASON}"
+          } >> "${GITHUB_OUTPUT}"
+        env:
+          INPUT_DATAPREP_SCOPE: ${{ inputs.dataprep_scope || 'none' }}
+          ARTIFACT_CHANGED: ${{ needs.changes.outputs.artifact_deces_backend }}
       - name: Build deces-backend image
+        if: steps.resolve.outputs.should_publish == 'true'
         run: make -C packages/deces-backend DATA_DIR=data NPM_AUDIT_DRY_RUN=true backend-build-image GIT_BRANCH=dev
         env:
           CD_GIT_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
       - name: Publish deces-backend image
+        if: steps.resolve.outputs.should_publish == 'true'
         run: make -C packages/deces-backend docker-push-backend GIT_BRANCH=dev
         env:
           CD_GIT_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: No-op deces-backend image
+        if: steps.resolve.outputs.should_publish != 'true'
+        run: echo "No publish needed for deces-backend (${{
+          steps.resolve.outputs.reason }})"
 
-  deces-ui:
-    name: Publish deces-ui image
+  ensure-deces-ui-image:
+    name: ensure-deces-ui-image
     needs: changes
-    if: >-
-      ${{
-        (
-          github.event_name == 'workflow_dispatch' &&
-          inputs.dataprep_scope == 'all'
-        ) ||
-        (
-          github.event_name == 'push' &&
-          needs.changes.outputs.deces_ui == 'true'
-        )
-      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    outputs:
+      should_publish: ${{ steps.resolve.outputs.should_publish }}
     steps:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref || github.ref }}
+      - name: Resolve deces-ui execution
+        id: resolve
+        run: |
+          SHOULD_PUBLISH=false
+          REASON=unchanged
+          if [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && [ "${INPUT_DATAPREP_SCOPE}" = "all" ]; then
+            SHOULD_PUBLISH=true
+            REASON=explicit_all_dispatch
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${ARTIFACT_CHANGED}" = "true" ]; then
+            SHOULD_PUBLISH=true
+            REASON=artifact_changed
+          fi
+          {
+            echo "should_publish=${SHOULD_PUBLISH}"
+            echo "reason=${REASON}"
+          } >> "${GITHUB_OUTPUT}"
+        env:
+          INPUT_DATAPREP_SCOPE: ${{ inputs.dataprep_scope || 'none' }}
+          ARTIFACT_CHANGED: ${{ needs.changes.outputs.artifact_deces_ui }}
       - name: Build deces-ui image
+        if: steps.resolve.outputs.should_publish == 'true'
         run: make APP=deces-ui build GIT_BRANCH=dev
         env:
           CD_GIT_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
       - name: Publish deces-ui image
+        if: steps.resolve.outputs.should_publish == 'true'
         run: make frontend-docker-push GIT_BRANCH=dev
         env:
           CD_GIT_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
           DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
+      - name: No-op deces-ui image
+        if: steps.resolve.outputs.should_publish != 'true'
+        run: echo "No publish needed for deces-ui (${{
+          steps.resolve.outputs.reason }})"
 
-  dataprep-small:
-    name: Publish dataprep small snapshot (${{ matrix.dataset.name }})
-    needs: changes
-    if: >-
-      ${{
-        (
-          github.event_name == 'repository_dispatch' &&
-          github.event.client_payload.ref == 'main'
-        ) ||
-        (
-          github.event_name == 'workflow_dispatch' &&
-          (
-            inputs.dataprep_scope == 'all' ||
-            inputs.dataprep_scope == 'small'
-          )
-        ) ||
-        (
-          github.ref == 'refs/heads/main' &&
-          needs.changes.outputs.dataprep_snapshot == 'true'
-        )
-      }}
+  ensure-dataprep-small-snapshot:
+    name: ensure-dataprep-small-snapshot (${{ matrix.dataset.name }})
+    needs:
+      - changes
+      - ensure-matchid-backend-image
     runs-on: ubuntu-latest
     timeout-minutes: 25
     permissions:
@@ -260,12 +313,37 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.client_payload.ref || github.ref }}
+      - name: Resolve dataprep small execution
+        id: resolve
+        run: |
+          SHOULD_RUN=false
+          REASON=unchanged
+          if [ "${GITHUB_EVENT_NAME}" = "repository_dispatch" ] && [ "${DISPATCH_REF}" = "main" ]; then
+            SHOULD_RUN=true
+            REASON=repository_dispatch_main
+          elif [ "${GITHUB_EVENT_NAME}" = "workflow_dispatch" ] && { [ "${INPUT_DATAPREP_SCOPE}" = "all" ] || [ "${INPUT_DATAPREP_SCOPE}" = "small" ]; }; then
+            SHOULD_RUN=true
+            REASON=explicit_small_dispatch
+          elif [ "${GITHUB_REF}" = "refs/heads/main" ] && [ "${ARTIFACT_CHANGED}" = "true" ]; then
+            SHOULD_RUN=true
+            REASON=artifact_changed
+          fi
+          {
+            echo "should_run=${SHOULD_RUN}"
+            echo "reason=${REASON}"
+          } >> "${GITHUB_OUTPUT}"
+        env:
+          DISPATCH_REF: ${{ github.event.client_payload.ref }}
+          INPUT_DATAPREP_SCOPE: ${{ inputs.dataprep_scope || 'none' }}
+          ARTIFACT_CHANGED: ${{ needs.changes.outputs.artifact_dataprep_snapshot == 'true' || needs.changes.outputs.artifact_matchid_backend == 'true' }}
       - name: Produce dataprep small snapshot
+        if: steps.resolve.outputs.should_run == 'true'
         run: make artifact-produce-dataprep-snapshot GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}" CHUNK_SIZE="${CHUNK_SIZE}" ES_THREADS="${ES_THREADS}" RECIPE_THREADS="${RECIPE_THREADS}" ES_MEM="${ES_MEM}"
         env:
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
       - name: Export dataprep small snapshot metadata
+        if: steps.resolve.outputs.should_run == 'true'
         run: |
           make -C packages/deces-infra elasticsearch-index-export ES_INDEX=deces ES_COUNT_FILE=${ES_COUNT_FILE} ES_SAMPLE_FILE=${ES_SAMPLE_FILE} ES_SAMPLE_SIZE=25 ES_SAMPLE_SEED=424242
           SNAPSHOT_NAME=$(make artifact-version-dataprep-snapshot FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}" | tail -1)
@@ -276,11 +354,13 @@ jobs:
             echo "count=$(cat ${ES_COUNT_FILE})"
           } | tee /tmp/dataprep-small-${{ matrix.dataset.name }}-snapshot-metadata.txt
       - name: Publish dataprep small snapshot
+        if: steps.resolve.outputs.should_run == 'true'
         run: make artifact-publish-dataprep-snapshot GIT_BRANCH=dev FILES_TO_PROCESS="${FILES_TO_PROCESS}" REPOSITORY_BUCKET="${REPOSITORY_BUCKET}"
         env:
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
       - name: Upload dataprep small snapshot metadata
+        if: steps.resolve.outputs.should_run == 'true'
         uses: actions/upload-artifact@v4
         with:
           name: dataprep-small-${{ matrix.dataset.name }}-snapshot-metadata
@@ -288,30 +368,16 @@ jobs:
             /tmp/dataprep-small-${{ matrix.dataset.name }}-snapshot-metadata.txt
             /tmp/dataprep-small-${{ matrix.dataset.name }}-snapshot.count
             /tmp/dataprep-small-${{ matrix.dataset.name }}-snapshot.sample.json
+      - name: No-op dataprep small snapshot
+        if: steps.resolve.outputs.should_run != 'true'
+        run: echo "No dataprep small snapshot run needed (${{
+          steps.resolve.outputs.reason }})"
 
-  dataprep-year:
-    name: Publish dataprep year snapshot
-    needs: changes
-    if: >-
-      ${{
-        (
-          github.event_name == 'repository_dispatch' &&
-          github.event.client_payload.ref == 'main'
-        ) ||
-        (
-          github.event_name == 'workflow_dispatch' &&
-          github.ref == 'refs/heads/main' &&
-          (
-            inputs.dataprep_scope == 'all' ||
-            inputs.dataprep_scope == 'year' ||
-            inputs.deploy_target == 'dev'
-          )
-        ) ||
-        (
-          github.ref == 'refs/heads/main' &&
-          needs.changes.outputs.dataprep_snapshot == 'true'
-        )
-      }}
+  ensure-dataprep-year-snapshot:
+    name: ensure-dataprep-year-snapshot
+    needs:
+      - changes
+      - ensure-matchid-backend-image
     runs-on: ubuntu-latest
     timeout-minutes: 360
     permissions:
@@ -348,6 +414,12 @@ jobs:
                 REASON=year_snapshot_missing
               fi
             fi
+          elif [ "${GITHUB_EVENT_NAME}" = "push" ] && [ "${ARTIFACT_CHANGED}" != "true" ]; then
+            SHOULD_RUN=false
+            REASON=unchanged
+          elif [ "${GITHUB_EVENT_NAME}" != "push" ] && [ "${GITHUB_EVENT_NAME}" != "repository_dispatch" ]; then
+            SHOULD_RUN=false
+            REASON=not_requested
           fi
           {
             echo "should_run=${SHOULD_RUN}"
@@ -356,6 +428,7 @@ jobs:
         env:
           INPUT_DATAPREP_SCOPE: ${{ inputs.dataprep_scope || 'none' }}
           INPUT_DEPLOY_TARGET: ${{ inputs.deploy_target || 'none' }}
+          ARTIFACT_CHANGED: ${{ needs.changes.outputs.artifact_dataprep_snapshot == 'true' || needs.changes.outputs.artifact_matchid_backend == 'true' }}
           STORAGE_ACCESS_KEY: ${{ secrets.STORAGE_ACCESS_KEY }}
           STORAGE_SECRET_KEY: ${{ secrets.STORAGE_SECRET_KEY }}
       - name: Install dataprep deploy SSH key
@@ -531,17 +604,18 @@ jobs:
           name: dataprep-year-snapshot-metadata
           path: |
             /tmp/dataprep-year-snapshot-metadata.txt
+      - name: No-op dataprep year snapshot
+        if: steps.year_context.outputs.should_run != 'true'
+        run: echo "No dataprep year snapshot run needed (${{
+          steps.year_context.outputs.reason }})"
 
-  deploy:
-    name: Deploy
+  deploy-dev:
+    name: deploy-dev
     needs:
       - changes
-      - dataprep-backend
-      - dataprep-frontend
-      - deces-backend
-      - deces-ui
-      - dataprep-small
-      - dataprep-year
+      - ensure-deces-backend-image
+      - ensure-deces-ui-image
+      - ensure-dataprep-year-snapshot
     if: >-
       ${{
         always() &&
@@ -552,9 +626,10 @@ jobs:
             github.event_name == 'push' &&
             github.ref == 'refs/heads/main' &&
             (
-              needs.changes.outputs.deces_backend == 'true' ||
-              needs.changes.outputs.deces_ui == 'true' ||
-              needs.changes.outputs.dataprep_snapshot == 'true'
+              needs.changes.outputs.artifact_deces_backend == 'true' ||
+              needs.changes.outputs.artifact_deces_ui == 'true' ||
+              needs.changes.outputs.artifact_dataprep_snapshot == 'true' ||
+              needs.changes.outputs.artifact_matchid_backend == 'true'
             )
           ) ||
           (

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,57 +16,67 @@ jobs:
     permissions:
       contents: read
     outputs:
-      tools: ${{ steps.filter.outputs.tools }}
-      dataprep_backend: ${{ steps.filter.outputs.dataprep_backend }}
-      dataprep_frontend: ${{ steps.filter.outputs.dataprep_frontend }}
-      deces_backend: ${{ steps.filter.outputs.deces_backend }}
-      deces_ui: ${{ steps.filter.outputs.deces_ui }}
-      deces_dataprep: ${{ steps.filter.outputs.deces_dataprep }}
+      artifact_matchid_backend: ${{ steps.detect.outputs.artifact_matchid_backend }}
+      artifact_matchid_frontend: ${{ steps.detect.outputs.artifact_matchid_frontend }}
+      artifact_deces_backend: ${{ steps.detect.outputs.artifact_deces_backend }}
+      artifact_deces_ui: ${{ steps.detect.outputs.artifact_deces_ui }}
+      artifact_dataprep_snapshot: ${{ steps.detect.outputs.artifact_dataprep_snapshot }}
+      integration_stack: ${{ steps.detect.outputs.integration_stack }}
+      tools: ${{ steps.detect.outputs.tools }}
     steps:
       - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
-        id: filter
         with:
-          filters: |
-            tools:
-              - 'Makefile'
-              - 'packages/tools/**'
-              - '.github/workflows/ci.yml'
-            dataprep_backend:
-              - 'Makefile'
-              - 'packages/dataprep-backend/**'
-              - 'packages/deces-dataprep/**'
-              - 'packages/tools/**'
-              - '.github/workflows/ci.yml'
-            dataprep_frontend:
-              - 'Makefile'
-              - 'packages/dataprep-frontend/**'
-              - 'packages/dataprep-backend/**'
-              - 'packages/deces-dataprep/**'
-              - 'packages/tools/**'
-              - '.github/workflows/ci.yml'
-            deces_backend:
-              - 'Makefile'
-              - 'packages/deces-backend/**'
-              - 'packages/deces-infra/**'
-              - 'packages/tools/**'
-              - '.github/workflows/ci.yml'
-            deces_ui:
-              - 'Makefile'
-              - 'packages/deces-ui/**'
-              - 'packages/deces-backend/**'
-              - 'packages/deces-infra/**'
-              - 'packages/tools/**'
-              - '.github/workflows/ci.yml'
-            deces_dataprep:
-              - 'Makefile'
-              - 'packages/deces-dataprep/**'
-              - 'packages/dataprep-backend/**'
-              - 'packages/dataprep-frontend/**'
-              - 'packages/deces-infra/**'
-              - 'packages/tools/**'
-              - 'scripts/**'
-              - '.github/workflows/ci.yml'
+          fetch-depth: 0
+      - name: Resolve artifact and integration flags
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          BASE_COMMIT="$(git merge-base "${BASE_SHA}" "${HEAD_SHA}")"
+          git diff --name-only "${BASE_COMMIT}" "${HEAD_SHA}" | LC_ALL=C sort -u > /tmp/changed-files.txt
+          touch /tmp/changed-files.txt
+
+          prefixed_version_files() {
+            local dir="$1"
+            make -s -C "${dir}" version-files | sed "s#^#${dir}/#" | LC_ALL=C sort -u
+          }
+
+          emit_flag() {
+            echo "$1=$2" >> "${GITHUB_OUTPUT}"
+          }
+
+          resolve_artifact_flag() {
+            local name="$1"
+            local dir="$2"
+            local files="/tmp/${name}.files"
+            prefixed_version_files "${dir}" > "${files}"
+            if grep -Fxf "${files}" /tmp/changed-files.txt > /dev/null 2>&1; then
+              emit_flag "${name}" true
+            else
+              emit_flag "${name}" false
+            fi
+          }
+
+          resolve_artifact_flag artifact_matchid_backend packages/dataprep-backend
+          resolve_artifact_flag artifact_matchid_frontend packages/dataprep-frontend
+          resolve_artifact_flag artifact_deces_backend packages/deces-backend
+          resolve_artifact_flag artifact_deces_ui packages/deces-ui
+          resolve_artifact_flag artifact_dataprep_snapshot packages/deces-dataprep
+
+          if grep -Eq '^(Makefile$|packages/tools/|\.github/workflows/ci\.yml$)' /tmp/changed-files.txt; then
+            emit_flag tools true
+          else
+            emit_flag tools false
+          fi
+
+          if grep -Eq '^(Makefile$|packages/tools/|packages/deces-infra/|scripts/|\.github/workflows/(ci|cd|release-prod)\.yml$)' /tmp/changed-files.txt; then
+            emit_flag integration_stack true
+          else
+            emit_flag integration_stack false
+          fi
 
   tools-swift:
     name: build docker swift
@@ -85,7 +95,11 @@ jobs:
   dataprep-backend-test:
     name: dataprep-backend pull request test
     needs: changes
-    if: needs.changes.outputs.dataprep_backend == 'true'
+    if: >-
+      ${{
+        needs.changes.outputs.artifact_matchid_backend == 'true' ||
+        needs.changes.outputs.integration_stack == 'true'
+      }}
     runs-on: ubuntu-latest
     env:
       GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -96,15 +110,40 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Resolve matchid-backend version
+        id: dataprep_backend_version
+        run: echo "app_version=$(make -s -C packages/dataprep-backend version | awk '{print $NF}')" >> "${GITHUB_OUTPUT}"
       - name: Configure monorepo dataprep backend
         run: make -C packages/deces-dataprep config
-      - name: Build or reuse backend image and run tests
-        run: make -C packages/dataprep-backend version backend-docker-check GIT_BRANCH=${GIT_BRANCH} || ( make -C packages/dataprep-backend backend-build GIT_BRANCH=${GIT_BRANCH} && make -C packages/dataprep-backend backend tests backend-stop GIT_BRANCH=${GIT_BRANCH} )
+      - name: Build or reuse backend image
+        run: make -C packages/dataprep-backend backend-docker-check GIT_BRANCH=${GIT_BRANCH} || make -C packages/dataprep-backend backend-build GIT_BRANCH=${GIT_BRANCH}
+      - name: Run dataprep-backend tests
+        run: make -C packages/dataprep-backend backend tests backend-stop GIT_BRANCH=${GIT_BRANCH}
+      - name: Save matchid-backend image artifact
+        run: docker save matchid/matchid-backend:${{ steps.dataprep_backend_version.outputs.app_version }} | gzip > /tmp/matchid-backend-image.tar.gz
+      - name: Upload matchid-backend image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: matchid-backend-image
+          path: /tmp/matchid-backend-image.tar.gz
+          if-no-files-found: error
 
   dataprep-frontend-test:
     name: dataprep-frontend pull request test
-    needs: changes
-    if: needs.changes.outputs.dataprep_frontend == 'true'
+    needs:
+      - changes
+      - dataprep-backend-test
+    if: >-
+      ${{
+        (
+          needs.dataprep-backend-test.result == 'success' ||
+          needs.dataprep-backend-test.result == 'skipped'
+        ) && (
+        needs.changes.outputs.artifact_matchid_frontend == 'true' ||
+        needs.changes.outputs.artifact_matchid_backend == 'true' ||
+        needs.changes.outputs.integration_stack == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     env:
       BACKEND: ${{ github.workspace }}/packages/dataprep-backend
@@ -119,6 +158,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Configure monorepo dataprep frontend
         run: make -C packages/deces-dataprep config frontend-config
+      - name: Download matchid-backend image artifact
+        if: needs.dataprep-backend-test.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: matchid-backend-image
+          path: /tmp
+      - name: Load matchid-backend image artifact
+        if: needs.dataprep-backend-test.result == 'success'
+        run: docker load -i /tmp/matchid-backend-image.tar.gz
       - name: Build or reuse frontend image and start stack
         run: |
           make -C packages/dataprep-frontend version-files
@@ -128,7 +176,11 @@ jobs:
   deces-backend-build:
     name: deces-backend build docker image
     needs: changes
-    if: needs.changes.outputs.deces_backend == 'true'
+    if: >-
+      ${{
+        needs.changes.outputs.artifact_deces_backend == 'true' ||
+        needs.changes.outputs.integration_stack == 'true'
+      }}
     runs-on: ubuntu-latest
     env:
       GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -141,8 +193,21 @@ jobs:
 
   deces-backend-tests:
     name: deces-backend tests
-    needs: changes
-    if: needs.changes.outputs.deces_backend == 'true'
+    needs:
+      - changes
+      - deces-dataprep-locally
+    if: >-
+      ${{
+        (
+          needs.deces-dataprep-locally.result == 'success' ||
+          needs.deces-dataprep-locally.result == 'skipped'
+        ) && (
+          needs.changes.outputs.artifact_deces_backend == 'true' ||
+          needs.changes.outputs.artifact_dataprep_snapshot == 'true' ||
+          needs.changes.outputs.artifact_matchid_backend == 'true' ||
+          needs.changes.outputs.integration_stack == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     env:
       GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -168,8 +233,26 @@ jobs:
 
   deces-backend-artillery:
     name: deces-backend perf artillery
-    needs: changes
-    if: needs.changes.outputs.deces_backend == 'true'
+    needs:
+      - changes
+      - deces-dataprep-locally
+      - deces-backend-tests
+    if: >-
+      ${{
+        (
+          needs.deces-dataprep-locally.result == 'success' ||
+          needs.deces-dataprep-locally.result == 'skipped'
+        ) &&
+        (
+          needs.deces-backend-tests.result == 'success' ||
+          needs.deces-backend-tests.result == 'skipped'
+        ) && (
+          needs.changes.outputs.artifact_deces_backend == 'true' ||
+          needs.changes.outputs.artifact_dataprep_snapshot == 'true' ||
+          needs.changes.outputs.artifact_matchid_backend == 'true' ||
+          needs.changes.outputs.integration_stack == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     continue-on-error: true
     env:
@@ -200,8 +283,27 @@ jobs:
 
   deces-ui-pull-request-test:
     name: deces-ui pull request test
-    needs: changes
-    if: needs.changes.outputs.deces_ui == 'true'
+    needs:
+      - changes
+      - deces-dataprep-locally
+      - deces-backend-tests
+    if: >-
+      ${{
+        (
+          needs.deces-dataprep-locally.result == 'success' ||
+          needs.deces-dataprep-locally.result == 'skipped'
+        ) &&
+        (
+          needs.deces-backend-tests.result == 'success' ||
+          needs.deces-backend-tests.result == 'skipped'
+        ) && (
+          needs.changes.outputs.artifact_deces_ui == 'true' ||
+          needs.changes.outputs.artifact_deces_backend == 'true' ||
+          needs.changes.outputs.artifact_dataprep_snapshot == 'true' ||
+          needs.changes.outputs.artifact_matchid_backend == 'true' ||
+          needs.changes.outputs.integration_stack == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -240,8 +342,20 @@ jobs:
 
   deces-dataprep-locally:
     name: deces-dataprep locally
-    needs: changes
-    if: needs.changes.outputs.deces_dataprep == 'true'
+    needs:
+      - changes
+      - dataprep-backend-test
+    if: >-
+      ${{
+        (
+          needs.dataprep-backend-test.result == 'success' ||
+          needs.dataprep-backend-test.result == 'skipped'
+        ) && (
+        needs.changes.outputs.artifact_dataprep_snapshot == 'true' ||
+        needs.changes.outputs.artifact_matchid_backend == 'true' ||
+        needs.changes.outputs.integration_stack == 'true'
+        )
+      }}
     runs-on: ubuntu-latest
     env:
       GIT_BRANCH: ${{ github.head_ref || github.ref_name }}
@@ -249,6 +363,17 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+      - name: Configure local dataprep stack
+        run: make -C packages/deces-dataprep config
+      - name: Download matchid-backend image artifact
+        if: needs.dataprep-backend-test.result == 'success'
+        uses: actions/download-artifact@v4
+        with:
+          name: matchid-backend-image
+          path: /tmp
+      - name: Load matchid-backend image artifact
+        if: needs.dataprep-backend-test.result == 'success'
+        run: docker load -i /tmp/matchid-backend-image.tar.gz
       - name: Run small dataset
         run: |
           make -C packages/deces-dataprep all GIT_BRANCH=${GIT_BRANCH} FILES_TO_PROCESS=${FILES_TO_PROCESS} \

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -84,15 +84,33 @@ jobs:
           git merge-base --is-ancestor "${TAG_SHA}" origin/main
           PREVIOUS_PROD_TAG=$(git tag --list 'v*' --sort=-creatordate | grep -Fxv "${PROD_TAG}" | head -n 1 || true)
           DATAPREP_CHANGED=true
+          ARTIFACT_DATAPREP_SNAPSHOT=false
+          ARTIFACT_MATCHID_BACKEND=false
+          DATAPREP_RUNTIME_CHANGED=false
           if [ -n "${PREVIOUS_PROD_TAG}" ]; then
-            if git diff --quiet "${PREVIOUS_PROD_TAG}" "${PROD_TAG}" -- \
-              Makefile \
-              packages/deces-dataprep \
-              packages/dataprep-backend \
-              packages/dataprep-frontend \
-              packages/deces-infra \
-              packages/tools \
-              scripts; then
+            git diff --name-only "${PREVIOUS_PROD_TAG}" "${PROD_TAG}" | LC_ALL=C sort -u > /tmp/release-prod-changed-files.txt
+            touch /tmp/release-prod-changed-files.txt
+
+            prefixed_version_files() {
+              local dir="$1"
+              make -s -C "${dir}" version-files | sed "s#^#${dir}/#" | LC_ALL=C sort -u
+            }
+
+            prefixed_version_files packages/deces-dataprep > /tmp/release-prod-dataprep-snapshot.files
+            prefixed_version_files packages/dataprep-backend > /tmp/release-prod-matchid-backend.files
+
+            if grep -Fxf /tmp/release-prod-dataprep-snapshot.files /tmp/release-prod-changed-files.txt > /dev/null 2>&1; then
+              ARTIFACT_DATAPREP_SNAPSHOT=true
+            fi
+            if grep -Fxf /tmp/release-prod-matchid-backend.files /tmp/release-prod-changed-files.txt > /dev/null 2>&1; then
+              ARTIFACT_MATCHID_BACKEND=true
+            fi
+            if grep -Eq '^(Makefile$|packages/tools/|packages/deces-infra/|scripts/|\.github/workflows/release-prod\.yml$)' /tmp/release-prod-changed-files.txt; then
+              DATAPREP_RUNTIME_CHANGED=true
+            fi
+            if [ "${ARTIFACT_DATAPREP_SNAPSHOT}" != "true" ] && \
+               [ "${ARTIFACT_MATCHID_BACKEND}" != "true" ] && \
+               [ "${DATAPREP_RUNTIME_CHANGED}" != "true" ]; then
               DATAPREP_CHANGED=false
             fi
           fi
@@ -101,6 +119,9 @@ jobs:
             echo "tag_sha=${TAG_SHA}"
             echo "previous_prod_tag=${PREVIOUS_PROD_TAG}"
             echo "dataprep_changed=${DATAPREP_CHANGED}"
+            echo "artifact_dataprep_snapshot=${ARTIFACT_DATAPREP_SNAPSHOT}"
+            echo "artifact_matchid_backend=${ARTIFACT_MATCHID_BACKEND}"
+            echo "dataprep_runtime_changed=${DATAPREP_RUNTIME_CHANGED}"
             echo "release_mode=${RELEASE_MODE}"
           } >> "${GITHUB_OUTPUT}"
 

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ export DATAPREP_VERSION_OVERRIDE ?=
 export DATA_VERSION_OVERRIDE ?=
 export DATA_VERSION_SOURCE ?= storage
 export DATA_VERSION_INPUT_DIR ?=
+dataprep_version_inputs := $(shell cd ${DATAPREP_PATH} && export LC_COLLATE=C; export LC_ALL=C; cat tagfiles.version | xargs -I '{}' find {} -type f | egrep -v '.tar.gz$$|.pyc$$|.gitignore$$' | sort)
 export FILES_TO_PROCESS?=deces-((19[7-9][0-9]|20(0[0-9]|1[0-9]|2[0-4]))|202[56]-m(0[1-9]|1[0-2]))\.txt\.gz
 export FILES_TO_PROCESS_TEST=deces-2020-m01.txt.gz
 export FILES_TO_PROCESS_DEV=deces-2020-m[0-1][0-9].txt.gz
@@ -310,11 +311,8 @@ ifneq (${DATAPREP_VERSION_OVERRIDE},)
 ${DATAPREP_VERSION_FILE}: FORCE
 	@printf '%s\n' "${DATAPREP_VERSION_OVERRIDE}" > ${DATAPREP_VERSION_FILE}
 else
-${DATAPREP_VERSION_FILE}: ${DATAPREP_PATH}/Makefile ${DATAPREP_PATH}/projects/deces-dataprep/recipes/deces_dataprep.yml ${DATAPREP_PATH}/projects/deces-dataprep/datasets/deces_index.yml
-	@cat ${DATAPREP_PATH}/Makefile\
-		${DATAPREP_PATH}/projects/deces-dataprep/recipes/deces_dataprep.yml\
-		${DATAPREP_PATH}/projects/deces-dataprep/datasets/deces_index.yml\
-	| sha1sum | awk '{print $1}' | cut -c-8 > ${DATAPREP_VERSION_FILE}
+${DATAPREP_VERSION_FILE}: $(addprefix ${DATAPREP_PATH}/,${dataprep_version_inputs})
+	@cd ${DATAPREP_PATH} && export LC_COLLATE=C; export LC_ALL=C; cat tagfiles.version | xargs -I '{}' find {} -type f | egrep -v '.tar.gz$$|.pyc$$|.gitignore$$' | sort | xargs cat | sha1sum - | sed 's/\(........\).*/\1/' > ${DATAPREP_VERSION_FILE}
 endif
 
 dataprep-version: ${DATAPREP_VERSION_FILE}

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,408 +1,70 @@
 # PLAN
 
-- [x] Lot 0 - Cadrage de migration fige
-  - [x] Exec
-    - [x] Creer la branche d'integration dediee au rebase monorepo
-    - [x] Figer dans une spec la matrice des SHAs importes et des branches upstream cibles
-    - [x] Figer dans une spec la liste des ecarts monorepo voulus vs ecarts non voulus
-    - [x] Decider et documenter que l'execution de reference se fait depuis la racine
-    - [x] Decider et documenter le role cible de `deces-infra`
-    - [x] Decider et documenter le role cible de `tools`
-    - [x] Decider et documenter la strategie de configuration hors git
-    - [x] Figer et documenter que `deploy-remote` est la voie canonique de deploiement preprod et prod a ce stade
-    - [x] Sortir `deploy-k8s` du chemin critique et le placer en roadmap
-    - [x] Figer et documenter que le contrat d'artefacts de reference de la chaine complete est `image backend` + `image deces-backend` + `image deces-ui` + `snapshot Elasticsearch esdata_${DATAPREP_VERSION}_${DATA_VERSION}`
-    - [x] Figer et documenter que l'artefact de reference de `deces-dataprep` pour `deploy-remote` est le snapshot Elasticsearch `esdata_${DATAPREP_VERSION}_${DATA_VERSION}`
-  - [x] Tests
-    - [x] Verifier la coherence entre `PLAN.md` et les specs
-    - [x] Verifier la coherence entre artefacts de reference, execution du dataprep, `deploy-remote` et preprod cible
-    - [x] Verifier que les decisions actees couvrent bien `deces-dataprep`, `deces-backend`, `deces-ui` et `deces-infra`
-  - [x] UAT
-    - [x] Gate: je te presente la matrice upstream, les ecarts voulus, les artefacts de reference complets et la voie de deploiement canonique
-    - [x] Gate: tu valides le cadrage du lot 0 avant tout rattrapage upstream
+## Remaining Issues
 
-- [x] Lot 1 - Rattrapage upstream de `tools` et `deces-dataprep`
-  - [x] Exec
-    - [x] Relever precisement les 2 commits upstream manquants de `packages/tools`
-    - [x] Integrer le commit `19bdb29` de `packages/tools` (`checksums changed their address in datagouv`)
-    - [x] Integrer le commit `3797919` de `packages/tools` (`lets fix again : no more checksum in datagouv ...`)
-    - [x] Documenter les ecarts residuels conserves pour `packages/tools`
-    - [x] Relever precisement les 2 commits upstream manquants de `packages/deces-dataprep`
-    - [x] Integrer le commit `d12b125` de `packages/deces-dataprep` (`feat: update FILES_TO_PROCESS regex for year 2026`)
-    - [x] Integrer le commit `e0489f1` de `packages/deces-dataprep` (`Merge pull request #158 ... year-2026`)
-    - [x] Conserver l'import upstream `FILES_TO_PROCESS` as is dans son commit de rattrapage, sans melanger de correction monorepo
-    - [x] Documenter les ecarts residuels conserves pour `packages/deces-dataprep`
-    - [x] Corriger en commit separe l'usage local inutile de `sudo` dans `packages/tools` (`config-proxy` et `docker-config-proxy`) pour respecter les regles du monorepo et debloquer les validations `make`
-    - [x] Faire reutiliser a `packages/deces-dataprep` les prerequis mutualises du monorepo pour `config`, `network` et `vm_max` afin de debloquer les gates `make` du lot 1 sans rouvrir le lot 4
-    - [x] Debloquer le `frontend` historique utilise par `packages/deces-dataprep` en neutralisant l'audit npm uniquement pour le `dev` local
-  - [x] Tests
-    - [x] Ne compter comme validation du lot 1 que des executions via cibles `make`
-    - [x] Valider le calcul canonique du tag de donnees via `make data-version` a la racine et `make -C packages/deces-dataprep data-tag`
-    - [x] Valider le lancement local cible de `packages/deces-dataprep` via `make -C packages/deces-dataprep dev`
-    - [x] Valider un run minimal de dataprep en environnement de dev via `make -C packages/deces-dataprep recipe-run`
-    - [x] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 1
-  - [x] UAT
-    - [x] Gate: je te presente les commits rattrapes, les ecarts residuels et les preuves de test `tools` + `deces-dataprep`
-    - [x] Gate: tu valides que le lot 1 est termine et qu'on peut ouvrir le lot 2
+- [ ] GitHub Actions deprecations
+  - update third-party actions still warning on Node 20 deprecation
+- [ ] Dataprep remote performance
+  - investigate the remaining delta on true `year/full` remote runs
+  - keep the post-merge option `SCW prebaked dataprep image` as a separate follow-up, not in the current workstream
 
-- [x] Lot 2 - Rattrapage upstream de `deces-backend`
-  - [x] Exec
-    - [x] Relever precisement tous les commits upstream manquants de `packages/deces-backend`
-    - [x] Integrer le commit `b3a91cc` de `packages/deces-backend` (`Update score.ts`)
-    - [x] Integrer le commit `8a38acd` de `packages/deces-backend` (`Merge pull request #491 ... Update score.ts`)
-    - [x] Integrer le commit `d8eda70` de `packages/deces-backend` (`move contact mail to contact@matchid.io`)
-    - [x] Integrer le commit `8dcdfc3` de `packages/deces-backend` (`Merge pull request #492 ... new-contact-mail`)
-    - [x] Integrer le commit `c37bd0d` de `packages/deces-backend` (`update vuln in package-lock`)
-    - [x] Integrer le commit `f73db56` de `packages/deces-backend` (`push mail validation code duration to 6 hours`)
-    - [x] Integrer le commit `367c0f1` de `packages/deces-backend` (`Merge pull request #500 ... code-validation-duration`)
-    - [x] Integrer le commit `794b3b6` de `packages/deces-backend` (`Add rate limit to send OTP mail function`)
-    - [x] Integrer le commit `79cc134` de `packages/deces-backend` (`Add test for send email rate limit`)
-    - [x] Integrer le commit `747c0ff` de `packages/deces-backend` (`Apply exponential rate limit when sending emails frequently`)
-    - [x] Integrer le commit `b5dba5a` de `packages/deces-backend` (`fix: exp backoff; refine display; fix OTP delay`)
-    - [x] Integrer le commit `5894a91` de `packages/deces-backend` (`Merge pull request #502 ... send-email-ratelimit`)
-    - [x] Documenter les ecarts residuels conserves pour `packages/deces-backend`
-    - [x] Rendre le port Maildev local parametrable pour eviter les collisions et garder `make backend-dev` testable
-  - [x] Tests
-    - [x] Ne compter comme validation du lot 2 que des executions via cibles `make`
-    - [x] Valider le demarrage local cible de `packages/deces-backend` via `make backend-dev`
-    - [x] Preparer l'index Elasticsearch de reference requis par les tests backend via `make elasticsearch`
-    - [x] Rendre `make backend-dev-test` compatible avec l'image Alpine utilisee par le backend
-    - [x] Assurer la presence du fichier de test `clients_test.csv` au chemin attendu par `server.spec.ts`
-    - [x] Isoler `bulk.spec.ts` pour qu'il ne lance pas de vrais jobs et ne pollue pas la suite backend
-    - [x] Garantir un singleton des workers bulk `processStream` pendant la suite backend pour eviter les collisions entre fichiers de tests
-    - [x] Attendre explicitement le readiness check dans `make backend-dev` avant de considerer le backend dev demarre
-    - [x] Serialiser l'execution inter-fichiers de Vitest pour `packages/deces-backend` afin d'eviter les collisions Redis/filesystem
-    - [x] Reinitialiser Redis backend et les fichiers `.enc` transitoires avant `make backend-test-vitest`
-    - [x] Arreter le backend dev resident avant `make backend-test-vitest` pour eviter deux workers backend concurrents sur Redis
-    - [x] Valider les tests backend cibles via `make backend-test-vitest` puis `make backend-dev-test`
-    - [x] Verifier explicitement les comportements touches par le rattrapage backend a travers les cibles `make` precedentes
-    - [x] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 2
-  - [x] UAT
-    - [x] Gate: je te presente les commits rattrapes, les ecarts residuels et les preuves de test backend
-    - [x] Gate: tu valides que le rattrapage backend reste bien limite au perimetre attendu
-    - [x] Gate: tu valides que le lot 2 est termine et qu'on peut ouvrir le lot 3
+## Current Workstream
 
-- [x] Lot 3 - Rattrapage upstream de `deces-ui`
-  - [x] Exec
-    - [x] Relever precisement tous les commits upstream manquants de `packages/deces-ui`
-    - [x] Integrer le commit `31b8079` de `packages/deces-ui` (`art 85`)
-    - [x] Integrer le commit `073cf2d` de `packages/deces-ui` (`Merge pull request #976 ... art-85`)
-    - [x] Integrer le commit `cc72ff0` de `packages/deces-ui` (`art 85`)
-    - [x] Integrer le commit `0ba3431` de `packages/deces-ui` (`Merge pull request #979 ... art-85`)
-    - [x] Integrer le commit `47bcb86` de `packages/deces-ui` (`move contact mail to contact@matchid.io`)
-    - [x] Integrer le commit `b828650` de `packages/deces-ui` (`Merge pull request #981 ... new-contact-mail`)
-    - [x] Integrer le commit `7875bc3` de `packages/deces-ui` (`avoid resetting token if there is an atypical network error`)
-    - [x] Integrer le commit `c51de22` de `packages/deces-ui` (`Merge pull request #983 ... reset-token`)
-    - [x] Integrer le commit `d0e25ab` de `packages/deces-ui` (`fix vulns in package-lock`)
-    - [x] Integrer le commit `12d50e1` de `packages/deces-ui` (`art 85`)
-    - [x] Integrer le commit `f50aa3c` de `packages/deces-ui` (`enable test to be flexible to validation code duration`)
-    - [x] Integrer le commit `8a53d7e` de `packages/deces-ui` (`Merge pull request #986 ... art-85`)
-    - [x] Integrer le commit `f182d28` de `packages/deces-ui` (`art 85`)
-    - [x] Integrer le commit `da04697` de `packages/deces-ui` (`Merge pull request #988 ... art-85`)
-    - [x] Integrer le commit `69713ba` de `packages/deces-ui` (`year 2026`)
-    - [x] Integrer le commit `43bd91a` de `packages/deces-ui` (`Merge pull request #993 ... 2026`)
-    - [x] Integrer le commit `08e33bb` de `packages/deces-ui` (`desactivate google analytics`)
-    - [x] Integrer le commit `82ba880` de `packages/deces-ui` (`Merge pull request #995 ... desactivate-google-analytics`)
-    - [x] Documenter les ecarts residuels conserves pour `packages/deces-ui`
-    - [x] Debloquer `make frontend-dev` en neutralisant l'audit npm uniquement pour le dev UI local
-    - [x] Debloquer `make frontend-test` en rendant la cible UI compatible avec les variables et services du monorepo
-  - [x] Tests
-    - [x] Ne compter comme validation du lot 3 que des executions via cibles `make`
-    - [x] Valider le demarrage local cible de `packages/deces-ui` via `make frontend-dev`
-    - [x] Valider les tests UI cibles via `MAILDEV_UI_PORT=37343 make frontend-test`
-    - [x] Verifier explicitement les comportements touches par le rattrapage UI a travers les cibles `make` precedentes
-    - [x] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 3
-  - [x] UAT
-    - [x] Gate: je te presente les commits rattrapes, les ecarts residuels et les preuves de test UI
-    - [x] Gate: tu valides que le rattrapage UI reste bien limite au perimetre attendu
-    - [x] Gate: tu valides que le lot 3 est termine et qu'on peut ouvrir le lot 4
+### CI/CD artifact contract and dependency DAG
 
-- [x] Lot 4 - Runtime monorepo stabilise
-  - [x] Exec
-    - [x] Verifier que `packages/dataprep-backend` reste aligne sur `matchID-project/backend:dev`
-    - [x] Verifier que `packages/dataprep-frontend` reste aligne sur `matchID-project/frontend:dev`
-    - [x] Corriger la dependance racine a `tagfiles.version`
-    - [x] Supprimer le `git clone backend` dans `packages/deces-dataprep/Makefile`
-    - [x] Remplacer dans `packages/deces-dataprep` les appels `backend/tools` par `packages/tools`
-    - [x] Remplacer dans `packages/deces-dataprep` les chemins `backend/*` par des chemins monorepo explicites
-    - [x] Mutualiser explicitement `network`, `vm_max`, `elasticsearch-start`, `elasticsearch-check` et `elasticsearch-stop` entre la racine et `deces-infra`
-    - [x] Faire consommer a `packages/deces-dataprep` les cibles Elasticsearch mutualisees au lieu du backend clone quand le monorepo fournit deja l'infra cible
-    - [x] Retirer ou neutraliser le doublon `packages/deces-backend/tools`
-    - [x] Definir le contrat des variables exportees par la racine
-    - [x] Definir le contrat des variables propres aux packages
-    - [x] Stabiliser la source de verite de `.data.sha1`
-    - [x] Stabiliser la source de verite de `.dataprep.sha1`
-    - [x] Traiter en commit separe l'harmonisation du moteur regex shell/Python autour de `FILES_TO_PROCESS` en forme POSIX-compatible (`[0-9]` plutot que `\d`) si l'ecart reste utile a corriger
-    - [x] Deplacer Redis de `deces-backend` vers `deces-infra`
-    - [x] Deplacer SMTP de `deces-backend` vers `deces-infra`
-    - [x] Clarifier la responsabilite des snapshots et restores entre `deces-infra`, `deces-dataprep` et `tools`
-  - [x] Tests
-    - [x] Valider le fonctionnement local cible de `packages/dataprep-backend`
-    - [x] Valider le fonctionnement local cible de `packages/dataprep-frontend`
-    - [x] Valider que chaque package peut etre execute sans dependance implicite a un clone externe
-    - [x] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 4
-  - [x] UAT
-    - [x] Gate: je te presente le runtime cible du monorepo, les contrats retenus et les preuves de test de non-regression structurelle
-    - [x] Gate: tu valides que le lot 4 est termine et qu'on peut ouvrir le lot 5
+Reference specs:
 
-- [x] Lot 5 - Chaine dev complete validee
-  - [x] Exec
-    - [x] Definir la commande canonique de bootstrap dev depuis la racine
-    - [x] Definir explicitement quelle image `backend` est la source canonique pour `deces-dataprep` en dev, en test et pour le deploiement
-    - [x] Definir la procedure canonique de restore snapshot
-    - [x] Definir la procedure canonique de run dataprep
-    - [x] Definir le protocole canonique de comparaison d'indexation entre le `deces-dataprep` original et le `deces-dataprep` monorepo sur un jeu de donnees de reference
-    - [x] Rendre `make dev` racine reproductible
-    - [x] Documenter la procedure de bootstrap dev
-  - [x] Tests
-    - [x] Valider `deces-infra` en local
-    - [x] Valider Elasticsearch en local
-    - [x] Valider Redis en local
-    - [x] Valider SMTP en local
-    - [x] Valider `deces-backend` en local
-    - [x] Valider `deces-ui` en local
-    - [x] Valider `deces-dataprep` en local
-    - [x] Valider la recuperation de `communes`
-    - [x] Valider la recuperation de `wikidata`
-    - [x] Valider la recuperation de `disposable-mail`
-    - [x] Valider la recuperation des sources Data.gouv
-    - [x] Rejouer une indexation de reference avec le `deces-dataprep` original et avec le `deces-dataprep` monorepo via des cibles `make`
-    - [x] Valider l'egalite exacte du nombre de documents indexes entre les deux runs de reference
-    - [x] Valider l'egalite de 1000 documents echantillonnes de maniere deterministe entre les deux runs de reference
-    - [x] Valider la compatibilite dataprep -> index -> backend -> ui
-    - [x] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 5
-  - [x] UAT
-    - [x] Gate: je te presente la procedure dev canonique, la source canonique de l'image `backend` pour `deces-dataprep`, la preuve de parite d'indexation et les preuves de fonctionnement bout en bout en local
-    - [x] Gate: tu valides que la chaine dev complete est acceptable et qu'on peut ouvrir le lot 6
+- [SPEC_EVOL_011_CI_ARTIFACT_CONTRACT](spec/SPEC_EVOL_011_CI_ARTIFACT_CONTRACT.md)
+- [SPEC_EVOL_012_CD_ARTIFACT_DAG](spec/SPEC_EVOL_012_CD_ARTIFACT_DAG.md)
 
-- [x] Lot 6 - CI monorepo et non-regression validees
-  - [x] Exec
-    - [x] Inventorier les workflows CI historiques par composant
-    - [x] Inventorier les workflows CD historiques par composant
-    - [x] Distinguer explicitement la CI de validation de la CI de build/publication d'artefacts
-    - [x] Mapper le job CI historique de `deces-dataprep` sur `make -C packages/deces-dataprep all`
-    - [x] Mapper le job CI historique de `deces-backend` sur build image, avec runtime backend couvert par le job historique `deces-ui`
-    - [x] Mapper le job CI historique de `deces-ui` sur build, `deploy-local`, `backend-test` et `frontend-test`
-    - [x] Mapper les jobs CI historiques de `dataprep-backend` et `dataprep-frontend`
-    - [x] Creer la CI racine du monorepo
-    - [x] Ajouter le job lint/build/tests de `deces-backend`
-    - [x] Ajouter le job build/tests de `deces-ui`
-    - [x] Ajouter le job de validation ciblee de `deces-dataprep`
-    - [x] Ajouter le job de validation ciblee de `tools`
-    - [x] Couvrir la chaine complete via les jobs historiques `deces-ui` et `deces-dataprep`
-    - [x] Definir les declenchements conditionnels par chemins modifies
-    - [x] Sortir la CI des dependances a l'environnement personnel
-    - [x] Confirmer qu'aucune donnee artificielle durable n'est necessaire en CI
-    - [x] Definir les secrets necessaires en CI
-    - [x] Definir les checks bloquants pour merge
-    - [x] Documenter que les jobs historiques de build/publication d'images de `dataprep-backend` et `dataprep-frontend` ne sont pas encore reconstruits dans la CI racine et relevent du lot 7
-    - [x] Documenter que les jobs historiques de deploiement relevent des lots 7 et 8, pas du lot 6
-  - [x] Tests
-    - [x] Valider un pipeline CI vert sur la branche d'integration
-    - [x] Valider que les jobs CI historiques couvrent bien les gates des lots precedents
-    - [x] Valider le tableau de mapping avant/apres des workflows CI par composant
-    - [x] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 6
-  - [x] UAT
-    - [x] Gate: je te presente le pipeline cible, sa couverture et les preuves de passage au vert
-    - [x] Gate: tu valides que la CI monorepo est suffisante pour ouvrir le lot 7
+### Exec
 
-- [x] Lot 7 - Artefacts de reference produits et publies
-  - [x] Exec
-    - [x] Definir la convention de versionnage monorepo des artefacts
-    - [x] Definir les artefacts versionnes par package
-    - [x] Definir la convention de calcul et d'exposition de `DATAPREP_VERSION` et `DATA_VERSION` pour le deploiement
-    - [x] Etablir la matrice exhaustive de parite workflow/job historique -> workflow/job monorepo
-      - [x] Lister `packages/tools/.github/workflows/actions.yml` / job `swift`
-      - [x] Lister `packages/tools/.github/workflows/actions.yml` / job `remote`
-      - [x] Lister `packages/dataprep-backend/.github/workflows/pull.yml` / job `test`
-      - [x] Lister `packages/dataprep-backend/.github/workflows/push.yml` / job `build`
-      - [x] Lister `packages/dataprep-backend/.github/workflows/deploy.yml` / job `deploy`
-      - [x] Lister `packages/dataprep-frontend/.github/workflows/pull.yml` / job `test`
-      - [x] Lister `packages/dataprep-frontend/.github/workflows/push.yml` / job `build`
-      - [x] Lister `packages/deces-backend/.github/workflows/dockerimage.yml` / job `build`
-      - [x] Lister `packages/deces-backend/.github/workflows/dockerimage.yml` / job `bulk`
-      - [x] Lister `packages/deces-ui/.github/workflows/pr.yml` / job `test`
-      - [x] Lister `packages/deces-ui/.github/workflows/push.yml` / job `build`
-      - [x] Lister `packages/deces-ui/.github/workflows/push.yml` / job `deploy`
-      - [x] Lister `packages/deces-ui/.github/workflows/logs-full.yml`
-      - [x] Lister `packages/deces-ui/.github/workflows/logs-update.yml`
-      - [x] Lister `packages/deces-dataprep/.github/workflows/pr.yml` / job `test`
-      - [x] Lister `packages/deces-dataprep/.github/workflows/small.yml` / job `build`
-      - [x] Lister `packages/deces-dataprep/.github/workflows/year.yml` / job `build`
-      - [x] Lister `packages/deces-dataprep/.github/workflows/full.yml` / job `check-previous-failure`
-      - [x] Lister `packages/deces-dataprep/.github/workflows/full.yml` / job `build`
-      - [x] Lister `packages/deces-dataprep/.github/workflows/push-dev.yml` / job `build`
-      - [x] Lister `packages/deces-dataprep/.github/workflows/push-master.yml` / job `build`
-    - [x] Pour chaque job historique liste, renseigner explicitement son statut cible (`ci.yml`, `cd.yml`, lot 8 ou retire du contrat)
-    - [x] Definir explicitement le sort des jobs historiques CD de build/publication d'images de `dataprep-backend` et `dataprep-frontend`
-    - [x] Si ces images restent requises, reconstruire leurs jobs CD de build/publication dans le monorepo
-    - [x] Definir explicitement le sort des jobs historiques CD de build/publication d'images de `deces-backend` et `deces-ui`
-    - [x] Reconstruire les jobs CD de build/publication d'artefacts requis dans le monorepo
-    - [x] Reconstruire le job CD GitHub de publication du snapshot dataprep dans le monorepo
-    - [x] Figer la picture complete lots 6/7/8 `upstream -> monorepo`, service par service et job par job
-  - [x] Tests
-    - [x] Prouver en local via `make` chaque job monorepo reconstruit au lot 7
-    - [x] Prouver sur GitHub Actions chaque job CD monorepo reconstruit au lot 7
-    - [x] Prouver sur GitHub Actions chaque job CI monorepo apres retour aux commandes make historiques
-    - [x] Capturer pour chaque preuve GitHub le workflow, le job, le `run id` et le statut final
-    - [x] Verifier localement le contenu des artefacts produits par les jobs reconstruits quand un artefact est attendu
-    - [x] Valider le build local de l'image `matchid-backend`
-    - [x] Valider la publication locale de l'image `matchid-backend`
-    - [x] Valider la publication GitHub de l'image `matchid-backend`
-    - [x] Valider le build local de l'image `matchid-frontend`
-    - [x] Valider la publication locale de l'image `matchid-frontend`
-    - [x] Valider la publication GitHub de l'image `matchid-frontend`
-    - [x] Valider le build local de l'image `deces-backend`
-    - [x] Valider la publication locale de l'image `deces-backend`
-    - [x] Valider la publication GitHub de l'image `deces-backend`
-    - [x] Valider le build local de l'image `deces-ui`
-    - [x] Valider la publication locale de l'image `deces-ui`
-    - [x] Valider la publication GitHub de l'image `deces-ui`
-    - [x] Lever le blocage GitHub `DOCKER_PASSWORD` pour les jobs `Publish * image`
-    - [x] Valider la production du snapshot Elasticsearch `esdata_${DATAPREP_VERSION}_${DATA_VERSION}`
-    - [x] Valider la publication du snapshot Elasticsearch `esdata_${DATAPREP_VERSION}_${DATA_VERSION}`
-    - [x] Valider la publication GitHub du snapshot Elasticsearch `esdata_${DATAPREP_VERSION}_${DATA_VERSION}`
-    - [x] Valider la restauration du snapshot Elasticsearch `esdata_${DATAPREP_VERSION}_${DATA_VERSION}` dans le flux `deploy-remote`
-    - [x] Valider l'egalite stricte count + sample entre l'index avant suppression et l'index restaure depuis le snapshot artefact
-    - [x] Nettoyer `ci.yml` des validations inventees et revenir aux commandes `make` historiques des repos sources
-    - [x] Centraliser la matrice des cibles `make` CI/CD, runtime avec donnees et complements SCW lot 8 dans `spec/SPEC_EVOL_MAKE_CICD_CHECKLIST.md`
-    - [x] Produire le tableau paddé de demonstration `source -> monorepo -> preuve make -> preuve GH -> statut`
-    - [x] Produire le tableau paddé complet lots 6/7/8 `service -> job source -> job monorepo -> lot -> preuve -> statut`
-    - [x] Mettre a jour `spec/SPEC_EVOL_MAKE_CICD_CHECKLIST.md` avec les run ids GitHub CI verts apres correction
-    - [x] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 7
-  - [x] UAT
-    - [x] Gate: je te presente la picture complete lots 6/7/8 `upstream -> monorepo`, service par service, job par job, avec preuves `make` + GitHub
-    - [x] Gate: je te presente la matrice exhaustive des jobs historiques, leur sort cible et les preuves `make` + GitHub associees
-    - [x] Gate: je te presente les artefacts produits, leur versionnage, les jobs CD reconstruits et les preuves de publication/restauration
-    - [x] Gate: tu valides en UAT, apres `make clean elasticsearch-restore dev`, que les artefacts de reference sont suffisants pour ouvrir le lot 8
+- [ ] Restore the artifact invalidation contract
+  - [x] add `VERSION` to `packages/dataprep-backend/tagfiles.version`
+  - [x] create `packages/deces-dataprep/tagfiles.version`
+  - [x] make the dataprep snapshot hash consume `packages/deces-dataprep/tagfiles.version`
+- [x] Replace YAML artifact globs with inline `tagfiles.version` outputs
+  - [x] define `artifact_matchid_backend`
+  - [x] define `artifact_matchid_frontend`
+  - [x] define `artifact_deces_backend`
+  - [x] define `artifact_deces_ui`
+  - [x] define `artifact_dataprep_snapshot`
+  - [x] define `integration_stack`
+- [x] Rewire CI on top of those outputs
+  - [x] keep component jobs
+  - [x] trigger component jobs on explicit `artifact_*` dependencies plus `integration_stack`
+  - [x] express the deces chain through existing job conditions
+- [x] Rewire CD into explicit `ensure-*` jobs
+  - [x] ensure `matchid-backend` before dataprep snapshot production
+  - [x] ensure `deces-backend` and `deces-ui` before deploy
+  - [x] reduce deploy `needs` to runtime dependencies only
+- [ ] Extend the same artifact/DAG model to `release-prod`
+  - [x] align prod dataprep auto/full decision with the same inline `tagfiles.version` contract
+  - [ ] split `release-prod` into explicit `ensure-*` style stages
+    - [ ] introduce `ensure-matchid-backend-image-prod`
+    - [ ] introduce `ensure-prod-snapshot`
+    - [ ] introduce `deploy-prod`
+    - [ ] keep metadata publication as a terminal stage after successful deploy
+    - [ ] remove the remaining monolithic branch logic from `release-prod.yml`
+  - [ ] validate `release-prod` on the same artifact contract
+    - [ ] `deces-ui` only does not force prod dataprep full
+    - [ ] `deces-backend` only does not force prod dataprep full
+    - [ ] `dataprep-backend` forces prod dataprep full
+    - [ ] `deces-dataprep` forces prod dataprep full
+    - [ ] workflow-only changes keep the expected `integration` semantics without fake artifact invalidation
 
-- [x] Lot 8 - Preprod `dev-deces.matchid.io` operationnelle
-  - [x] Exec
-    - [x] Inventorier les images Docker encore pilotees par les anciens repos
-    - [x] Inventorier les buckets et snapshots encore pilotes par les anciens repos
-    - [x] Inventorier les volumes encore pilotes par les anciens repos
-    - [x] Inventorier DNS, certificats, monitoring et jobs de refresh encore pilotes par les anciens repos
-    - [x] Inventorier et trancher les cibles d'image SCW `update-base-image`, `deploy-docker-pull-base`, `SCW-instance-snapshot` et `SCW-instance-image`
-    - [x] Supprimer ou encadrer tout commit automatique encore declenche par une cible `make`
-    - [x] Definir l'environnement cible de `dev-deces.matchid.io`
-    - [x] Definir la configuration preprod hors git necessaire au monorepo
-    - [x] Definir explicitement le workflow CD de deploiement preprod depuis le monorepo
-    - [x] Reconstruire le job de deploiement preprod `deploy-remote` depuis le monorepo
-    - [x] Valider les prerequis et variables du flux `deploy-remote` pour la preprod
-    - [x] Garantir que le test public `deploy-remote-publish` cible `dev-deces.matchid.io` en preprod et non `deces.matchid.io`
-    - [x] Ajouter un declenchement manuel CD pre-merge qui garde `GIT_BRANCH=dev` et ne change que la branche clonee distante
-    - [x] Corriger le blocage TypeScript du build image `deces-backend` revele par le CD manuel sans changer le comportement webhook
-    - [x] Corriger l'amorcage SSH SCW de `deploy-remote` pour utiliser l'utilisateur `SCW_SSHUSER` et la cle privee locale
-    - [x] Corriger l'authentification Docker distante de `deploy-local` pour tirer les images privees publiees
-    - [x] Provisionner l'infra de preprod depuis le monorepo
-    - [x] Rendre disponible en preprod le snapshot Elasticsearch `esdata_${DATAPREP_VERSION}_${DATA_VERSION}`
-    - [x] Rendre disponible en preprod l'image `backend` necessaire a l'execution du dataprep
-    - [x] Deployer `deces-infra` en preprod
-    - [x] Deployer l'image `deces-backend` en preprod
-    - [x] Deployer l'image `deces-ui` en preprod
-    - [x] Executer le flux `deploy-remote` de bout en bout pour la preprod
-    - [x] Publier la configuration d'acces `dev-deces.matchid.io`
-    - [x] Rattraper l'evolution upstream `deces-ui` securite + art85 depuis `fix/art-85`
-    - [x] Corriger les ecarts CI/CD arbitres M1, H4, H5 et H6 sans changer le contrat upstream valide
-    - [x] Rebrancher le CD `dataprep-small` sur les deux datasets upstream `deces-2020-m01.txt.gz` et `deaths.txt.gz`
-    - [x] Rebrancher le CD `dataprep-year` sur `full-check` + `remote-all` SCW, en clonant le monorepo et en executant `packages/deces-dataprep`
-    - [x] Rebrancher le CD `dataprep-full` sur `full-check` + `remote-all` SCW, en clonant le monorepo et en executant `packages/deces-dataprep`
-    - [x] Documenter la passe d'arbitrage H1/H2/H3/H7 avant tout changement supplementaire de Makefile ou Dockerfile
-    - [x] Restaurer la sequence CI upstream de `deces-backend`: `backend-build-image`, `deploy-dependencies`, `backend-test-vitest`
-    - [x] Realigner la commande Vitest `deces-backend` sur l'upstream `npm run test --verbose`
-    - [x] Corriger H7 en remplacant le contournement `DATA_DIR=build-data` par le repertoire package-local upstream `DATA_DIR=data`
-    - [x] Corriger le montage Vitest CI de `deces-backend` pour reutiliser en absolu le repertoire `packages/deces-backend/data`
-  - [x] Tests
-    - [x] Valider la restauration effective du snapshot Elasticsearch par `deploy-remote` en preprod
-    - [x] Valider le test API en preprod
-    - [x] Valider le test UI en preprod
-    - [x] Valider la chaine dataprep -> index -> backend -> ui en preprod
-    - [x] Valider statiquement les workflows CI/CD apres correction des ecarts arbitres
-    - [x] Prouver sur GitHub Actions la CI complete apres correction H5/H7: run `24757045362`
-    - [x] Prouver sur GitHub Actions la CI apres rattrapage upstream `deces-ui`: run `24757200408`
-    - [x] Prouver sur GitHub Actions les jobs CD dataprep `small` et `year` reconstruits: runs `24777149351` et `24777914592`
-    - [x] Documenter le garde-fou `dataprep-full`: non lance depuis PR car le snapshot prod attendu est absent et l'execution publierait en prod
-    - [x] Valider l'observabilite preprod au niveau lot 8: `deploy-monitor` execute sans erreur, `MONITOR_BUCKET` absent documente
-    - [x] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 8
-  - [x] UAT
-    - [x] Gate: je te presente la preprod `dev-deces.matchid.io`, son etat, les preuves de deploiement et les resultats de test
-    - [x] Gate: tu valides que la preprod monorepo est acceptable et qu'on peut ouvrir le lot 9
+### Validation Matrix
 
-- [ ] Lot 9 - Substitution complete du processus actuel
-  - [ ] Exec
-    - [x] Executer le protocole `make` temporaire de non-regression data original-vs-monorepo pour `deces-dataprep`
-    - [x] Ancrer la reference de non-regression data sur les derniers jobs upstream `small`, `year`, `full`, `push-dev` et `push-master`
-    - [x] Relever le snapshot upstream `master` de reference (tag + count prod associe)
-    - [x] Tracer la preuve acceptee dans `spec/SPEC_EVOL_007_PREUVE_PARITE_DATAPREP.md` et retirer l'outillage temporaire du tronc courant
-    - [x] Conserver le comportement upstream cible: `dataprep-full` produit le snapshot, le deploiement UI prod reste declenche separement et explicitement
-    - [x] Ecrire le runbook de bascule
-    - [x] Ecrire le runbook de rollback
-    - [x] Documenter l'etat GitHub live du monorepo et la piste transitoire `feat/* -> dev -> master`, puis acter son abandon au profit de `main + tags`
-    - [x] Acter dans une spec dediee le pivot final `dev/master` -> `main + tags`, le contrat `APP_RELEASE + SNAPSHOT`, le versionning monorepo et le dataprep mensuel auto-redeploy
-    - [ ] Remplacer `dev` par `main` comme branche d'integration/preprod et branche par defaut
-    - [ ] Supprimer `master` du repo racine une fois `main` et les tags de release en place
-    - [ ] Definir et appliquer la convention de tags package (`deces-ui/v*`, `deces-backend/v*`, `dataprep-frontend/v*`, `dataprep-backend/v*`) et de release prod (`v*`)
-    - [ ] Documenter que le tag prod `v*` est cree manuellement apres validation UAT smoke sur `dev-deces.matchid.io`
-    - [x] Definir et implementer les cibles `make` de versionning independant par package
-      - [x] Pour les packages Node versionnes, faire porter la version finale par les `package.json` de la PR mergee sur `main`
-      - [x] Ajouter `.changeset/README.md` comme documentation technique transitoire si `changesets` reste utile en helper interne
-      - [x] Si `changesets` est conserve, l'encapsuler derriere `make` sans commit de release separe apres merge
-    - [x] Introduire une source de version semantique dediee pour `packages/dataprep-backend` hors `changesets`
-      - [x] Ajouter `packages/dataprep-backend/VERSION` avec la base semantique courante `0.4.0`
-      - [x] Faire porter la version finale par `packages/dataprep-backend/VERSION` dans la PR mergee sur `main`
-    - [x] Realigner le contrat de version d'artefact sur l'upstream: format `tag-VERSION`, `tag` issu de `package.json` ou `VERSION`, hash `tagfiles.version` conserve
-    - [x] Supprimer la dependance entre tag Git prod `v*` et resolution des versions d'images dans `release-prod.yml` et `dataprep-monthly.yml`
-    - [ ] Reconfigurer la gouvernance GitHub pour `main` et pour les tags proteges, en supprimant les protections `master`
-    - [ ] Refondre `ci.yml` et `cd.yml` vers le cycle `pull_request -> main`, `push -> main`, `push tag v*` et `schedule/workflow_dispatch` dataprep mensuel
-      - [x] Basculer `ci.yml` sur `pull_request -> main` et `push -> main`
-      - [x] Sortir la prod de `cd.yml` et creer `release-prod.yml` pour `push tag v*`
-      - [x] Aligner `release-prod.yml` sur `push tag v*`
-      - [x] Ajouter le workflow mensuel `dataprep-monthly.yml`
-      - [x] Garantir que `GIT_BRANCH=dev/master` reste strictement inchange dans les artefacts d'exploitation, seuls les refs Git et workflows changeant
-      - [x] Garantir qu'un changement `tools`, `deces-dataprep` ou `dataprep-backend` sur `main` execute `small` puis `year`, puis seulement le deploy preprod `deces-ui`
-    - [x] Conserver le switch `nginx-conf-apply` / bastion dans le chemin critique tant que la bascule CDN complete n'est pas explicitement ouverte
-    - [ ] Executer le CD `dataprep-full` depuis le dernier tag prod ou le contexte prod valide, jamais depuis une branche PR
-    - [x] Configurer le dataprep mensuel en mode alerte seule en cas d'echec, sans retry automatique
-    - [ ] Basculer la source de build et release vers le monorepo
-    - [ ] Valider que les anciens repos ne sont plus sources de build ou de deploy
-    - [ ] Statuer et reconstruire si necessaire le job lourd `deces-backend` upstream `bulk` / artillery (`backend-perf-clinic`, `test-perf-v1`) avant la substitution finale
-    - [ ] Passer les anciens repos en lecture seule ou archive
-    - [ ] Mettre a jour la documentation de gouvernance et d'exploitation
-  - [ ] Tests
-    - [x] Valider sur le commit de preuve `41c099bb` le protocole temporaire de contrat Elasticsearch
-    - [x] Valider sur le commit de preuve `41c099bb` la parite data original-vs-monorepo sur `deces-2020-m01.txt.gz`: count `60557`, sample deterministe `10000`, mapping et types
-    - [x] Valider sur le commit de preuve `41c099bb` la parite data original-vs-monorepo sur `deaths.txt.gz`: count `1355728`, sample deterministe `10000`, mapping et types
-    - [ ] Prouver la gouvernance GitHub `feat/* -> main` sur le repo racine
-    - [ ] Prouver qu'un merge sur `main` deploie bien `dev-deces.matchid.io`
-    - [ ] Prouver qu'un tag manuel `v*` sur `main` deploie bien la prod
-    - [ ] Prouver que le dataprep mensuel resolve le dernier tag prod, produit un snapshot `full` et redeploie automatiquement la prod avec ce tag
-    - [x] Verifier localement les versions d'artefacts attendues via `make artifact-version-*`:
-      - [x] `deces-ui` -> `0.4.0-0f7395`
-      - [x] `deces-backend` -> `1.0.0-d36bd4`
-      - [x] `dataprep-backend` -> `0.4.0-e4d91b`
-      - [x] `dataprep-frontend` -> `1.0.1-2d96b8`
-    - [ ] Prouver qu'un merge sur `main` publie `dev-deces.matchid.io` via le switch nginx actuel
-    - [ ] Prouver qu'un tag `v*` publie `deces.matchid.io` via le switch nginx actuel
-    - [ ] Prouver qu'un echec du dataprep mensuel emet une alerte sans retry automatique
-    - [ ] Valider le runbook de bascule
-    - [ ] Valider le runbook de rollback
-    - [ ] Valider que le processus monorepo couvre bien `deces-dataprep` et `deces-ui`
-    - [ ] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 9
-  - [ ] UAT
-    - [ ] Gate: je te presente les preuves de substitution complete du processus actuel
-    - [ ] Gate: tu valides la bascule finale vers le monorepo comme source unique de build et de deploiement
+- [x] `packages/tools/**` only
+- [x] `packages/dataprep-backend/**` only
+- [x] `packages/deces-dataprep/**` only
+- [x] `packages/deces-backend/**` only
+- [x] `packages/deces-ui/**` only
+- [x] workflow files only
+- [x] combined `dataprep-backend + deces-dataprep`
 
-- [ ] Lot 10 - Cleanup final et archivage
-  - [ ] Exec
-    - [ ] Nettoyer ou ignorer proprement les fichiers d'etat et artefacts locaux generes par les validations (`data-tag`, `recipe-run`, `s3-pull`, artefacts de build temporaires)
-    - [ ] Archiver les specs closes dans `spec/archive/` une fois la migration complete
-    - [ ] Supprimer ou neutraliser les cibles legacy devenues sans objet apres mutualisation
-    - [ ] Nettoyer les commentaires morts et les chemins historiques restes dans les Makefiles
-    - [ ] Finaliser la documentation d'exploitation et de contribution du monorepo
-  - [ ] Tests
-    - [ ] Verifier que le cleanup ne casse aucun workflow `make` retenu
-    - [ ] Verifier que les documents archives restent tracables depuis le plan ou la doc de gouvernance
-    - [ ] Lister explicitement les tests executes et leur resultat avant entree en UAT du lot 10
-  - [ ] UAT
-    - [ ] Gate: je te presente le diff final de cleanup et l'etat documentaire final
-    - [ ] Gate: tu valides la cloture propre de la migration
+### UAT
+
+- [ ] Gate: present the final artifact invalidation contract based on `tagfiles.version`
+- [ ] Gate: present the final CI integration contract and the final CD DAG
+- [ ] Gate: present the validation matrix results before rollout to `main`

--- a/packages/dataprep-backend/tagfiles.version
+++ b/packages/dataprep-backend/tagfiles.version
@@ -4,4 +4,5 @@ docker-compose.yml
 Dockerfile
 referential_data
 requirements.txt
+VERSION
 tagfiles.version

--- a/packages/deces-dataprep/Makefile
+++ b/packages/deces-dataprep/Makefile
@@ -1,6 +1,6 @@
 SHELL=/bin/bash
 
-export DATAPREP_VERSION := $(shell cat Makefile projects/deces-dataprep/recipes/deces_dataprep.yml projects/deces-dataprep/datasets/deces_index.yml  | sha1sum | awk '{print $1}' | cut -c-8)
+export DATAPREP_VERSION := $(shell export LC_COLLATE=C; export LC_ALL=C; cat tagfiles.version | xargs -I '{}' find {} -type f | egrep -v '.tar.gz$$|.pyc$$|.gitignore$$' | sort | xargs cat | sha1sum - | sed 's/\(........\).*/\1/')
 export APP=deces-dataprep
 export APP_GROUP=matchID
 export PWD := $(shell pwd)
@@ -152,6 +152,9 @@ data-tag: ${DATA_TAG}
 
 dataprep-version:
 	@echo ${DATAPREP_VERSION}
+
+version-files:
+	@export LC_COLLATE=C; export LC_ALL=C; cat tagfiles.version | xargs -I '{}' find {} -type f | egrep -v '.tar.gz$$|.pyc$$|.gitignore$$' | sort
 
 ${BACKUP_CHECK}: data-tag
 	${MAKE} -s -C ${MONOREPO_TOOLS_PATH} get-catalog CATALOG=${BACKUP_CHECK}\

--- a/packages/deces-dataprep/tagfiles.version
+++ b/packages/deces-dataprep/tagfiles.version
@@ -1,0 +1,4 @@
+Makefile
+projects/deces-dataprep/recipes/deces_dataprep.yml
+projects/deces-dataprep/datasets/deces_index.yml
+tagfiles.version

--- a/spec/SPEC_EVOL_011_CI_ARTIFACT_CONTRACT.md
+++ b/spec/SPEC_EVOL_011_CI_ARTIFACT_CONTRACT.md
@@ -1,0 +1,180 @@
+# SPEC_EVOL_011 - Contrat CI d'invalidation d'artefacts
+
+## Contexte
+
+La CI du monorepo melangeait jusque-la deux sujets differents:
+
+- l'invalidation d'artefact;
+- le rerun des tests quand l'orchestration ou l'infra change.
+
+Le pivot pris vers un detecteur Python repo-wide est inutilement complexe pour
+ce besoin. L'intention de depart etait plus simple:
+
+- `tagfiles.version` est la source unique des entrees d'artefact;
+- la logique doit rester lisible directement dans les workflows;
+- la chaine `matchid-backend -> dataprep -> deces-backend -> deces-ui` doit se
+  lire dans les conditions des jobs, pas dans un moteur de regles externe.
+
+## Probleme
+
+Les ecarts a corriger sont:
+
+1. `packages/dataprep-backend/tagfiles.version` n'incluait pas `VERSION`.
+2. le snapshot dataprep n'avait pas de `tagfiles.version` dedie;
+3. `ci.yml` utilisait des globs larges qui ne correspondaient pas au vrai
+   contrat d'artefact;
+4. la proposition de detecteur repo dedie ajoutait de la complexite sans gain
+   suffisant.
+
+## Objectif
+
+Definir un contrat CI dans lequel:
+
+- les flags `artifact_*` sont calcules directement depuis `tagfiles.version`;
+- le workflow reste autoportant, sans script detecteur dedie;
+- les dependances de chaine sont exprimees explicitement dans les `if:` des jobs
+  existants.
+
+## Non-objectifs
+
+- ajouter un moteur de regles repo-wide;
+- introduire un job `stack-integration` dedie dans ce lot;
+- refondre le runtime local.
+
+## Contrat d'invalidation des artefacts
+
+Pour chaque artefact versionne, le flag `artifact_*` vaut `true` si et
+seulement si un fichier du `tagfiles.version` correspondant a change.
+
+Le calcul se fait directement dans le workflow:
+
+1. calcul du range Git utile;
+2. liste des fichiers modifies;
+3. `make -s -C <package> version-files`;
+4. comparaison directe entre ces fichiers et le diff Git.
+
+## Cas cibles
+
+`artifact_matchid_backend`
+
+- source: `packages/dataprep-backend/tagfiles.version`
+- correction requise: `VERSION` doit etre present dans ce fichier
+
+`artifact_matchid_frontend`
+
+- source: `packages/dataprep-frontend/tagfiles.version`
+
+`artifact_deces_backend`
+
+- source: `packages/deces-backend/tagfiles.version`
+
+`artifact_deces_ui`
+
+- source: `packages/deces-ui/tagfiles.version`
+
+`artifact_dataprep_snapshot`
+
+- source: `packages/deces-dataprep/tagfiles.version`
+
+## Signal d'integration
+
+Le rerun d'integration ne doit pas etre deduit d'un faux changement de
+`tag-VERSION`.
+
+On garde donc un signal separe:
+
+- `integration_stack`
+
+Ce signal reste volontairement simple et explicite. Il vaut `true` si le diff
+contient au moins un changement dans:
+
+- `Makefile`
+- `packages/tools/**`
+- `packages/deces-infra/**`
+- `scripts/**`
+- `.github/workflows/ci.yml`
+- `.github/workflows/cd.yml`
+- `.github/workflows/release-prod.yml`
+
+Ce signal n'est pas derive des flags `artifact_*`.
+
+## Contrat des jobs CI
+
+Le lot courant ne rajoute pas de nouveau job d'integration global.
+
+La chaine est exprimee en elargissant les conditions des jobs existants:
+
+- `dataprep-backend pull request test`
+  - `artifact_matchid_backend || integration_stack`
+- `dataprep-frontend pull request test`
+  - `artifact_matchid_frontend || artifact_matchid_backend || integration_stack`
+- `deces-dataprep locally`
+  - `artifact_dataprep_snapshot || artifact_matchid_backend || integration_stack`
+- `deces-backend build/tests/artillery`
+  - `artifact_deces_backend || artifact_dataprep_snapshot || artifact_matchid_backend || integration_stack`
+- `deces-ui pull request test`
+  - `artifact_deces_ui || artifact_deces_backend || artifact_dataprep_snapshot || artifact_matchid_backend || integration_stack`
+
+But:
+
+- si `matchid-backend` change, on rerun le dataprep puis les validations aval;
+- si seul `deces-ui` change, on ne rerun pas toute la chaine inutilement;
+- si `tools` ou l'orchestration changent, on rerun les jobs impacts sans
+  pretendre qu'un artefact a change.
+
+## Partage de l'image `matchid-backend` en CI
+
+Le job `dataprep-backend pull request test` est la source canonique de l'image
+`matchid-backend` dans la CI.
+
+Contrat cible:
+
+1. le job prepare l'image via `docker-check || build`;
+2. il execute les tests backend dataprep sur cette image;
+3. si les tests passent, il exporte l'image Docker comme artefact GitHub
+   Actions;
+4. les jobs aval qui ont besoin de `matchid-backend` la rechargent via
+   `docker load` au lieu de la recalculer.
+
+Jobs consommateurs dans ce lot:
+
+- `deces-dataprep locally`
+- `dataprep-frontend pull request test`
+
+But:
+
+- supprimer le rebuild/redownload redondant de `matchid-backend` entre jobs;
+- garantir que le dataprep small ne s'execute pas sur un backend dataprep non
+  teste;
+- garder un seul job canonique pour la production de cette image dans la PR.
+
+Non-objectif dans ce lot:
+
+- scinder `dataprep-backend pull request test` en jobs `build-image` et `tests`.
+
+## Regle de build
+
+Dans les jobs CI qui consomment des images:
+
+- on commence par `docker-check || build`;
+- on ne rebuild pas si le tag existe deja.
+
+## Matrice de validation attendue
+
+Cas minimum a verifier:
+
+- `packages/tools/**` seul
+- `packages/dataprep-backend/**` seul
+- `packages/deces-dataprep/**` seul
+- `packages/deces-backend/**` seul
+- `packages/deces-ui/**` seul
+- workflow files seuls
+- `packages/dataprep-backend/** + packages/deces-dataprep/**`
+
+Pour chaque cas, la validation doit tracer:
+
+- les flags `artifact_*`;
+- la valeur de `integration_stack`;
+- les jobs CI declenches;
+- les jobs CI skippes;
+- les rebuilds evites ou effectifs.

--- a/spec/SPEC_EVOL_012_CD_ARTIFACT_DAG.md
+++ b/spec/SPEC_EVOL_012_CD_ARTIFACT_DAG.md
@@ -1,0 +1,243 @@
+# SPEC_EVOL_012 - DAG CD des artefacts et du deploiement
+
+## Contexte
+
+Le monorepo publie maintenant les artefacts et deploie `dev-deces.matchid.io`
+depuis `main`, mais le graphe de dependances CD n'est pas encore explicite dans
+le workflow.
+
+Le symptome principal est connu:
+
+- un job dataprep peut partir avant que l'image `matchid-backend` du meme
+  commit soit effectivement disponible.
+
+Ce probleme ne vient pas du contrat Make local, deja realigne. Il vient du DAG
+GitHub Actions.
+
+## Probleme
+
+Les ecarts observes au depart de ce chantier sont:
+
+1. `Publish dataprep small snapshot` ne depend pas explicitement de
+   `Publish matchid-backend image`.
+2. `Publish dataprep year snapshot` ne depend pas explicitement de
+   `Publish matchid-backend image`.
+3. Le `deploy` depend de plus de jobs que ses vraies dependances runtime.
+4. Le workflow melange publication, reuse/no-op et orchestration dans des jobs
+   difficiles a raisonner.
+
+## Objectif
+
+Definir un DAG CD explicite qui:
+
+- garantit la disponibilite du bon artefact au bon moment;
+- encode les vraies dependances runtime;
+- remplace les races par des jobs `ensure-*` toujours presents;
+- reste pilote directement par `tagfiles.version`, sans detecteur repo dedie.
+
+## Non-objectifs
+
+- changer le modele de release prod lui-meme;
+- refondre les cibles Make;
+- traiter ici la perf infra SCW du dataprep.
+
+## Graphe cible des artefacts
+
+Le bon graphe n'est pas une simple chaine lineaire de build.
+
+### Artefacts independants
+
+Ces artefacts ont leur propre cycle de build/publish:
+
+- `matchid-backend`
+- `matchid-frontend`
+- `deces-backend`
+- `deces-ui`
+
+### Artefact compose
+
+Le snapshot dataprep depend de:
+
+- l'image `matchid-backend`
+
+### Dependances runtime du deploy
+
+Le deploy `deces.matchid.io` ou `dev-deces.matchid.io` depend de:
+
+- l'image `deces-backend`
+- l'image `deces-ui`
+- le snapshot dataprep a restaurer
+
+Le deploy ne depend pas runtime de:
+
+- `matchid-frontend`
+- `small snapshots`
+
+sauf si un besoin d'exploitation explicite l'impose plus tard.
+
+## Jobs cibles
+
+Le workflow CD doit utiliser des jobs `ensure-*` toujours presents.
+
+Liste cible:
+
+- `ensure-matchid-backend-image`
+- `ensure-matchid-frontend-image`
+- `ensure-deces-backend-image`
+- `ensure-deces-ui-image`
+- `ensure-dataprep-small-snapshot`
+- `ensure-dataprep-year-snapshot`
+- `deploy-dev`
+
+Chaque job `ensure-*` decide en interne:
+
+- `publish`
+- ou `reuse/no-op`
+
+mais ne disparait jamais du DAG.
+
+## DAG cible
+
+### Dataprep
+
+- `ensure-dataprep-small-snapshot` needs `ensure-matchid-backend-image`
+- `ensure-dataprep-year-snapshot` needs `ensure-matchid-backend-image`
+
+Invariant:
+
+- un snapshot dataprep ne doit jamais partir avant la disponibilite de l'image
+  `matchid-backend` correspondant au commit courant.
+
+### Deploy dev
+
+- `deploy-dev` needs:
+  - `ensure-deces-backend-image`
+  - `ensure-deces-ui-image`
+  - `ensure-dataprep-year-snapshot`
+
+Invariant:
+
+- le deploy attend uniquement ses dependances runtime reelles.
+
+## Semantique de no-op
+
+Un job `ensure-*` doit toujours produire un resultat exploitable, meme quand il
+ne republie rien.
+
+Semantique attendue:
+
+- sortie `published=true|false`
+- version d'artefact resolue dans tous les cas
+- logs distinguant clairement:
+  - `publish`
+  - `reuse`
+  - `skip because unchanged but version already available`
+
+But:
+
+- garder un DAG lisible;
+- eviter les effets de bord de `needs` sur des jobs absents ou `skipped`.
+
+## Articulation avec la resolution des changements
+
+Le CD doit consommer les memes flags d'artefact que la CI, definis dans
+[SPEC_EVOL_011_CI_ARTIFACT_CONTRACT](SPEC_EVOL_011_CI_ARTIFACT_CONTRACT.md).
+
+Usage:
+
+- `artifact_*` est calcule inline dans le workflow a partir de `make version-files`;
+- `artifact_*` decide si le job `ensure-*` doit publier ou reuser;
+- le DAG `needs` decide l'ordre d'execution;
+- le deploy ne depend jamais d'un glob de fichiers, seulement d'artefacts et de
+  snapshots resolves.
+
+## Extension a `release-prod`
+
+Le meme modele doit s'appliquer ensuite a `release-prod`:
+
+- la decision `full` ne doit plus etre derivee d'un `git diff` ad hoc;
+- la production du snapshot prod depend de `matchid-backend`;
+- le deploy prod depend du snapshot requis + `deces-backend` + `deces-ui`;
+- les jobs doivent rester `ensure-*`, pas des branches conditionnelles
+  difficilement lisibles.
+
+### Lot 2 cible
+
+Le second lot ne doit pas reouvrir tout `release-prod`. Il doit seulement
+aligner sa structure sur le modele deja pose dans `cd.yml`.
+
+Jobs cibles:
+
+- `ensure-matchid-backend-image-prod`
+- `ensure-prod-snapshot`
+- `deploy-prod`
+- `publish-release-prod-metadata`
+
+### DAG cible du lot 2
+
+- `ensure-prod-snapshot` needs `ensure-matchid-backend-image-prod`
+- `deploy-prod` needs:
+  - `ensure-prod-snapshot`
+  - `ensure-deces-backend-image` ou sa resolution equivalente dans le workflow
+  - `ensure-deces-ui-image` ou sa resolution equivalente dans le workflow
+- `publish-release-prod-metadata` needs `deploy-prod`
+
+### Semantique cible du lot 2
+
+`ensure-matchid-backend-image-prod`
+
+- publie si `artifact_matchid_backend=true`;
+- reuse/no-op sinon;
+- expose la version d'image resolue dans tous les cas.
+
+`ensure-prod-snapshot`
+
+- lance un vrai `full` si:
+  - `artifact_dataprep_snapshot=true`
+  - ou `artifact_matchid_backend=true`
+  - ou un changement runtime explicite impose de revalider la chaine dataprep
+- reuse le snapshot precedent sinon;
+- expose `snapshot_name`, `dataprep_version`, `data_version` dans tous les cas.
+
+`deploy-prod`
+
+- ne consomme que:
+  - `snapshot_name`
+  - `dataprep_version`
+  - `data_version`
+  - `deces-backend`
+  - `deces-ui`
+- ne redecide pas lui-meme s'il faut un `full`.
+
+`publish-release-prod-metadata`
+
+- reste un job terminal;
+- publie les metadata de release seulement apres succes du deploy;
+- ne porte aucune logique de decision sur les artefacts.
+
+### Non-objectifs du lot 2
+
+- ne pas changer les secrets;
+- ne pas changer la strategie de tag prod;
+- ne pas traiter ici la perf dataprep remote;
+- ne pas reouvrir la logique de build/version des artefacts.
+
+## Matrice de validation attendue
+
+Cas minimum a verifier:
+
+- `packages/dataprep-backend/**` seul
+- `packages/deces-dataprep/**` seul
+- `packages/deces-backend/**` seul
+- `packages/deces-ui/**` seul
+- `packages/tools/**` seul
+- workflow files seuls
+- `packages/dataprep-backend/** + packages/deces-dataprep/**`
+
+Pour chaque cas, la validation doit tracer:
+
+- artefacts republies ou reuses;
+- ordre effectif des jobs;
+- absence de race `matchid-backend -> dataprep`;
+- dependances effectives du deploy;
+- absence de rebuild/publish inutile quand `tag-VERSION` ne change pas.


### PR DESCRIPTION
## Summary
- restore the artifact invalidation contract around `tagfiles.version`
- add `VERSION` to `packages/dataprep-backend/tagfiles.version`
- create `packages/deces-dataprep/tagfiles.version` and align dataprep snapshot hashing on it
- compute artifact and integration flags inline in GitHub Actions from `version-files`, without a repository-level detector script
- rewire `ci.yml` triggers around those flags and encode the CI chain `dataprep -> deces-backend -> deces-ui`
- make `deces-dataprep locally` build or reuse `matchid-backend` before running the small dataset
- rewire `cd.yml` around ensure-style jobs with an explicit `matchid-backend -> dataprep` dependency
- partially align `release-prod.yml` on the same artifact contract while leaving the structural split for a follow-up lot
- refresh `PLAN.md` and add the new CI/CD specs for this workstream

## Validation
- `python -c "import yaml, pathlib; [yaml.safe_load(pathlib.Path(p).read_text()) for p in [.github/workflows/ci.yml, .github/workflows/cd.yml, .github/workflows/release-prod.yml]]; print(yaml-ok)"`
- `git diff --check`
- `make -s dataprep-version`
- `make -s -C packages/deces-dataprep dataprep-version`
- PR CI supervision on `#23`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Refactored CI/CD workflows to enhance artifact detection and streamline deployment job dependencies for improved reliability

* **Documentation**
  * Added comprehensive specifications for CI/CD artifact contract and deployment dependency management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->