### PR TITLE
fix: reject placeholder deploy secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -596,9 +596,17 @@ export $(DEPLOY_REMOTE_REQUIRED_VARS) $(DEPLOY_REMOTE_OPTIONAL_VARS)
 deploy-remote-preflight: config-minimal
 	@missing=0; \
 	for var in ${DEPLOY_REMOTE_REQUIRED_VARS}; do \
-		if [ -z "$${!var}" ]; then \
+		value="$${!var}"; \
+		if [ -z "$$value" ]; then \
 			echo "missing $$var"; \
 			missing=1; \
+		elif [ "$$value" = "-" ] || [ "$$value" = "override/me" ]; then \
+			echo "invalid $$var"; \
+			missing=1; \
+		else \
+			case "$$value" in \
+				"<"*">") echo "invalid $$var"; missing=1 ;; \
+			esac; \
 		fi; \
 	done; \
 	if [ "$$missing" -ne 0 ]; then exit 1; fi; \


### PR DESCRIPTION
## Summary

Reject placeholder values in `deploy-remote-preflight` for required deployment variables.

## Why

`TOOLS_STORAGE_ACCESS_KEY=-` and `TOOLS_STORAGE_SECRET_KEY=-` were previously treated as valid because the preflight only checked for non-empty values. That allowed Fluent Bit to deploy with invalid S3 credentials.

## Validation

- `deploy-remote-preflight` accepts valid required values.
- `deploy-remote-preflight` rejects `TOOLS_STORAGE_ACCESS_KEY=-`.
- `deploy-remote-preflight` rejects `TOOLS_STORAGE_ACCESS_KEY=<AWS_ACCESS_KEY_ID>`.
- `deploy-remote-preflight` rejects `TOOLS_STORAGE_ACCESS_KEY=override/me`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced validation in the deployment preflight check to more strictly detect missing or invalid configuration values and provide improved error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->