### PR TITLE
fix: avoid recursive backend make defaults

### DIFF
--- a/packages/deces-backend/Makefile
+++ b/packages/deces-backend/Makefile
@@ -13,8 +13,8 @@ export APP_DNS?=deces.matchid.io
 export USE_TTY := $(shell test -t 1 && USE_TTY="-t")
 
 # make options
-export MAKEBIN = $(shell which make)
-export MAKE = ${MAKEBIN} --no-print-directory -s
+export MAKEBIN := $(shell command -v make || echo make)
+export MAKE := ${MAKEBIN} --no-print-directory -s
 
 # docker compose
 export DC ?= docker compose
@@ -35,9 +35,17 @@ export API_SSL?=1
 export APP_URL?=http$([ "$API_SSL" == 1 ] && echo "s" || echo "")://${APP_DNS}
 export API_EMAIL?=contact@matchid.io
 export BACKEND_TOKEN_USER?=matchid.project@gmail.com
-export BACKEND_TOKEN_KEY?=$(shell openssl rand -base64 16)
-export BACKEND_TOKEN_PASSWORD?=$(shell openssl rand -base64 16)
-export NPM_REGISTRY = $(shell echo $$NPM_REGISTRY )
+ifndef BACKEND_TOKEN_KEY
+export BACKEND_TOKEN_KEY := $(shell openssl rand -base64 16)
+else
+export BACKEND_TOKEN_KEY
+endif
+ifndef BACKEND_TOKEN_PASSWORD
+export BACKEND_TOKEN_PASSWORD := $(shell openssl rand -base64 16)
+else
+export BACKEND_TOKEN_PASSWORD
+endif
+export NPM_REGISTRY ?=
 export NPM_VERBOSE ?= 1
 export REDIS_DATA=${DATA_DIR}/redisdata
 export BULK_TIMEOUT = 600
@@ -54,7 +62,11 @@ export SMTP_PORT?=1025
 export MAILDEV_UI_PORT?=1080
 export BACKEND_TEST_SCRIPT?=test
 export SMTP_USER?=${API_EMAIL}
-export SMTP_PWD?=$(shell echo $$RANDOM )
+ifndef SMTP_PWD
+export SMTP_PWD := $(shell echo $$RANDOM)
+else
+export SMTP_PWD
+endif
 
 # Backupdir
 export BACKUP_DIR = ${APP_PATH}/backup

--- a/packages/deces-backend/tagfiles.version
+++ b/packages/deces-backend/tagfiles.version
@@ -3,6 +3,7 @@ docker-compose.yml
 docker-compose-dev-backend.yml
 docker-compose-smtp.yml
 Dockerfile
+Makefile
 eslint.config.mjs
 package.json
 package-lock.json


### PR DESCRIPTION
Fixes the dev deploy hang observed after secrets preflight passed.\n\nRoot cause: packages/deces-backend/Makefile exported recursive $(shell ...) defaults. On the remote instance, make config repeatedly expanded them while resolving deces-backend version, keeping deploy-dev stuck in make -C matchID/matchID config.\n\nValidation:\n- env -i PATH=/usr/bin:/bin HOME=$HOME make -C packages/deces-backend --no-print-directory version\n- make -C packages/deces-backend --no-print-directory version\n- timeout 10 make --no-print-directory -n config\n- copied patched Makefile to /tmp on the stuck dev instance and ran make -f /tmp/deces-backend.Makefile.patched version successfully in 5.1s

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced backend build configuration for improved robustness and deterministic behavior
  * Strengthened secret generation and management for authentication and email services

<!-- end of auto-generated comment: release notes by coderabbit.ai -->