### PR TITLE
fix: handle datagouv resources without checksums

### DIFF
--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -1087,7 +1087,7 @@ datagouv-to-aws: aws-get-catalog datagouv-get-files
 ${DATAGOUV_CATALOG}: config ${DATA_DIR}
 	@echo getting ${DATAGOUV_DATASET} catalog from data.gouv API ${DATAGOUV_API}
 	@curl -s --fail ${DATAGOUV_API}/${DATAGOUV_DATASET}/ | \
-		jq  -cr '.resources[] | (.url | sub(".*/";"")) + " " +.checksum.value + " " + .url' | sort > ${DATAGOUV_CATALOG}
+		jq  -cr '.resources[] | (.url | sub(".*/";"")) + " no-more-checksum " + .url' | sort > ${DATAGOUV_CATALOG}
 
 datagouv-get-catalog: ${DATAGOUV_CATALOG}
 
@@ -1114,10 +1114,13 @@ datagouv-get-files: ${DATAGOUV_CATALOG}
 		for file in $$(awk '{print $$1}' ${DATA_DIR}/tmp.list); do\
 			if [ ! -f ${DATA_DIR}/$$file.gz.sha1 ]; then\
 				echo getting $$file ;\
-				grep $$file ${DATA_DIR}/tmp.list | awk '{print $$3}' | xargs curl -s > ${DATA_DIR}/$$file; \
+				url=$$(grep $$file ${DATA_DIR}/tmp.list | awk '{print $$3}'); \
+				if [ -z "$$url" ]; then echo "error: missing datagouv URL for $$file"; exit 1; fi; \
+				curl -fsSL "$$url" > ${DATA_DIR}/$$file; \
+				if [ ! -s ${DATA_DIR}/$$file ]; then echo "error: empty datagouv download for $$file"; exit 1; fi; \
 				grep $$file ${DATA_DIR}/tmp.list | awk '{print $$2}' > ${DATA_DIR}/$$file.sha1.src; \
 				sha1sum < ${DATA_DIR}/$$file | awk '{print $$1}' > ${DATA_DIR}/$$file.sha1.dst; \
-				((diff ${DATA_DIR}/$$file.sha1.src ${DATA_DIR}/$$file.sha1.dst > /dev/null) || echo error downloading $$file); \
+				((diff ${DATA_DIR}/$$file.sha1.src ${DATA_DIR}/$$file.sha1.dst > /dev/null) || echo warning: checksum mismatch for $$file); \
 				if [[ "$$file" == "deces"* ]]; then\
 					if [ "$$file" \> "deces-2010" ];then\
 						recode utf8..latin1 ${DATA_DIR}/$$file;\
@@ -1138,10 +1141,13 @@ datagouv-get-files: ${DATAGOUV_CATALOG}
 		for file in $$(awk '{print $$1}' ${DATA_DIR}/tmp.force.list); do\
 			if [ ! -f ${DATA_DIR}/$$file.gz.sha1 ]; then\
 				echo force-getting $$file ;\
-				grep $$file ${DATA_DIR}/tmp.force.list | awk '{print $$3}' | xargs curl -s > ${DATA_DIR}/$$file; \
+				url=$$(grep $$file ${DATA_DIR}/tmp.force.list | awk '{print $$3}'); \
+				if [ -z "$$url" ]; then echo "error: missing datagouv URL for $$file"; exit 1; fi; \
+				curl -fsSL "$$url" > ${DATA_DIR}/$$file; \
+				if [ ! -s ${DATA_DIR}/$$file ]; then echo "error: empty datagouv download for $$file"; exit 1; fi; \
 				grep $$file ${DATA_DIR}/tmp.force.list | awk '{print $$2}' > ${DATA_DIR}/$$file.sha1.src; \
 				sha1sum < ${DATA_DIR}/$$file | awk '{print $$1}' > ${DATA_DIR}/$$file.sha1.dst; \
-				((diff ${DATA_DIR}/$$file.sha1.src ${DATA_DIR}/$$file.sha1.dst > /dev/null) || echo error downloading $$file); \
+				((diff ${DATA_DIR}/$$file.sha1.src ${DATA_DIR}/$$file.sha1.dst > /dev/null) || echo warning: checksum mismatch for $$file); \
 				gzip ${DATA_DIR}/$$file; \
 				sha1sum ${DATA_DIR}/$$file.gz > ${DATA_DIR}/$$file.gz.sha1; \
 				((i++));\


### PR DESCRIPTION
## Summary
- Port upstream tools datagouv catalog handling to keep filename/checksum/url columns stable when data.gouv returns checksum=null.
- Use curl -fsSL and fail before gzip/upload when the URL is missing or the downloaded file is empty.
- Downgrade checksum mismatch to a warning, matching upstream tools no-more-checksum behavior.

## Test Plan
- Reproduced the previous broken catalog shape for deces-2026-m04.txt before the patch: URL shifted out of column 3.
- Deleted s3:fichier-des-personnes-decedees/deces-2026-m04.txt.gz, then ran make -C packages/tools datagouv-to-storage targeting deces-2026-m04 from this branch.
- Verified public object: content-length 1718618 and gzip decompression line count 52982.
- git diff --check -- packages/tools/Makefile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced download error handling with stricter validation during data ingestion.
  * Checksum mismatches now generate warnings instead of errors, improving process resilience.
  * Improved file validation to ensure downloaded data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->