### PR TITLE
fix: align prod deploy volume type

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -538,7 +538,7 @@ jobs:
       ES_MEM_PROD: 8192m
       SCW_FLAVOR_PROD: GP1-XS
       SCW_VOLUME_SIZE_PROD: 60000000000
-      SCW_VOLUME_TYPE_PROD: l_ssd
+      SCW_VOLUME_TYPE_PROD: sbs_volume
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Align release-prod app server root volume type with the current SCW base image.
- Keep prod app flavor and volume size unchanged.

## Verification
- Ran isolated SCW provisioning check: GP1-XS + image e88c1486... + sbs root volume was accepted.
- Ran git diff --check.
- Ran a local assertion that release-prod uses sbs_volume and no longer l_ssd for SCW_VOLUME_TYPE_PROD.

Note: the prod snapshot esdata_eb84b2eb_66b53416 exists and was created successfully, but the recalculating full workflow attempt was manually recovered; there is not yet a fully green full recalculation job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production infrastructure configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->