### PR TITLE
fix: quote remote action commands

### DIFF
--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -1273,7 +1273,9 @@ remote-actions: remote-deploy
 			else\
 				MAKE_APP_PATH=${REMOTE_TOOLS_MAKE_PATH};\
 			fi;\
-			ssh ${SSHOPTS} $$U@$$H make -C $$MAKE_APP_PATH ${ACTIONS} STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY} ${REMOTE_ACTION_MAKEOVERRIDES};\
+			REMOTE_CMD=$$(bash ${TOOLS_PATH}/scripts/shell-quote-argv.sh make -C "$$MAKE_APP_PATH" ${ACTIONS}\
+				"STORAGE_ACCESS_KEY=${STORAGE_ACCESS_KEY}" "STORAGE_SECRET_KEY=${STORAGE_SECRET_KEY}" ${REMOTE_ACTION_MAKEOVERRIDES});\
+			ssh ${SSHOPTS} $$U@$$H "$$REMOTE_CMD";\
 		fi
 
 remote-test-api-in-vpc: ${CLOUD}-instance-get-tagged-hosts
@@ -1401,3 +1403,6 @@ ${GIT_BACKEND}:
 # tests for automation
 remote-config-test:
 	@/usr/bin/time -f %e make remote-actions ACTIONS="generate-test-file storage-push" remote-clean ${MAKEOVERRIDES}
+
+test-remote-actions-quoting:
+	@bash ${TOOLS_PATH}/tests/test_remote_actions_quoting.sh

--- a/packages/tools/scripts/shell-quote-argv.sh
+++ b/packages/tools/scripts/shell-quote-argv.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sep=""
+for arg in "$@"; do
+	quoted=${arg//\'/\'\\\'\'}
+	printf "%s'%s'" "$sep" "$quoted"
+	sep=" "
+done
+printf '\n'

--- a/packages/tools/tagfiles.tools.version
+++ b/packages/tools/tagfiles.tools.version
@@ -1,1 +1,2 @@
 Makefile
+scripts

--- a/packages/tools/tests/test_remote_actions_quoting.sh
+++ b/packages/tools/tests/test_remote_actions_quoting.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+QUOTE_ARGV="${ROOT_DIR}/scripts/shell-quote-argv.sh"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+MAKEFILE="${TMP_DIR}/Makefile"
+cat > "${MAKEFILE}" <<'MAKEFILE'
+print:
+	@printf 'GOALS=<%s> TITLE=<%s>\n' '$(MAKECMDGOALS)' '$(SLACK_TITLE)'
+
+full:
+	@echo FULL_TARGET_EXECUTED
+MAKEFILE
+
+unquoted_output=$(sh -c "make -s -f '${MAKEFILE}' print SLACK_TITLE=deces-dataprep - full")
+if ! printf '%s\n' "${unquoted_output}" | grep -q 'GOALS=<print full>'; then
+	echo "expected unquoted remote command to create a parasite full target" >&2
+	printf '%s\n' "${unquoted_output}" >&2
+	exit 1
+fi
+if ! printf '%s\n' "${unquoted_output}" | grep -q 'FULL_TARGET_EXECUTED'; then
+	echo "expected unquoted remote command to execute the parasite full target" >&2
+	printf '%s\n' "${unquoted_output}" >&2
+	exit 1
+fi
+
+remote_cmd=$(bash "${QUOTE_ARGV}" make -s -f "${MAKEFILE}" print "SLACK_TITLE=deces-dataprep - full")
+quoted_output=$(sh -c "${remote_cmd}")
+if ! printf '%s\n' "${quoted_output}" | grep -q 'GOALS=<print> TITLE=<deces-dataprep - full>'; then
+	echo "expected quoted remote command to preserve SLACK_TITLE and avoid parasite targets" >&2
+	printf '%s\n' "${quoted_output}" >&2
+	exit 1
+fi
+if printf '%s\n' "${quoted_output}" | grep -q 'FULL_TARGET_EXECUTED'; then
+	echo "quoted remote command unexpectedly executed the parasite full target" >&2
+	printf '%s\n' "${quoted_output}" >&2
+	exit 1
+fi
+
+echo "remote-actions quoting: ok"


### PR DESCRIPTION
## Summary
- quote remote make argv before SSH execution
- add regression test for SLACK_TITLE values containing spaces
- include tools scripts in tools version hash

## Test plan
- bash -n packages/tools/scripts/shell-quote-argv.sh packages/tools/tests/test_remote_actions_quoting.sh
- make -C packages/tools test-remote-actions-quoting

Closes #33