### PR TITLE
fix: harden deploy monitor install

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -634,7 +634,6 @@ jobs:
           ) ||
           (
             github.event_name == 'workflow_dispatch' &&
-            github.ref == 'refs/heads/main' &&
             inputs.deploy_target == 'dev'
           )
         )
@@ -646,6 +645,7 @@ jobs:
     env:
       APP_DNS: deces.matchid.io
       GIT_BRANCH: dev
+      REMOTE_DEPLOY_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
       DEPLOY_TARGET: ${{ github.event.inputs.deploy_target || 'none' }}
     steps:
       - uses: actions/checkout@v4
@@ -742,7 +742,8 @@ jobs:
         run: |
           make deploy-remote-preflight \
             GIT_BRANCH=$GIT_BRANCH \
-            REMOTE_DEPLOY_BRANCH=main \
+            REMOTE_DEPLOY_BRANCH=$REMOTE_DEPLOY_BRANCH \
+            ALLOW_NON_MAIN_DEV_DEPLOY=true \
             DEPLOY_TARGET=dev \
             APP_DNS=$APP_DNS \
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV \
@@ -751,7 +752,7 @@ jobs:
             CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
           make deploy-remote \
             GIT_BRANCH=$GIT_BRANCH \
-            REMOTE_DEPLOY_BRANCH=main \
+            REMOTE_DEPLOY_BRANCH=$REMOTE_DEPLOY_BRANCH \
             DEPLOY_TARGET=dev \
             APP_DNS=$APP_DNS \
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV REPOSITORY_BUCKET=$REPOSITORY_BUCKET_DEV \

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -634,6 +634,7 @@ jobs:
           ) ||
           (
             github.event_name == 'workflow_dispatch' &&
+            github.ref == 'refs/heads/main' &&
             inputs.deploy_target == 'dev'
           )
         )
@@ -645,7 +646,6 @@ jobs:
     env:
       APP_DNS: deces.matchid.io
       GIT_BRANCH: dev
-      REMOTE_DEPLOY_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
       DEPLOY_TARGET: ${{ github.event.inputs.deploy_target || 'none' }}
     steps:
       - uses: actions/checkout@v4
@@ -742,8 +742,7 @@ jobs:
         run: |
           make deploy-remote-preflight \
             GIT_BRANCH=$GIT_BRANCH \
-            REMOTE_DEPLOY_BRANCH=$REMOTE_DEPLOY_BRANCH \
-            ALLOW_NON_MAIN_DEV_DEPLOY=true \
+            REMOTE_DEPLOY_BRANCH=main \
             DEPLOY_TARGET=dev \
             APP_DNS=$APP_DNS \
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV \
@@ -752,7 +751,7 @@ jobs:
             CLOUD_SSHOPTS="-J${BASTION_USER_RESOLVED}@${BASTION_HOST_RESOLVED}"
           make deploy-remote \
             GIT_BRANCH=$GIT_BRANCH \
-            REMOTE_DEPLOY_BRANCH=$REMOTE_DEPLOY_BRANCH \
+            REMOTE_DEPLOY_BRANCH=main \
             DEPLOY_TARGET=dev \
             APP_DNS=$APP_DNS \
             FILES_TO_PROCESS=$FILES_TO_PROCESS_DEV REPOSITORY_BUCKET=$REPOSITORY_BUCKET_DEV \

--- a/Makefile
+++ b/Makefile
@@ -631,7 +631,7 @@ deploy-remote-preflight: config-minimal
 			echo "GIT_BRANCH=${GIT_BRANCH} is not the expected preprod runtime label dev"; \
 			exit 1; \
 		fi; \
-		if [ "${REMOTE_DEPLOY_BRANCH}" != "${GIT_BRANCH_MAIN}" ]; then \
+		if [ "${REMOTE_DEPLOY_BRANCH}" != "${GIT_BRANCH_MAIN}" ] && [ "${ALLOW_NON_MAIN_DEV_DEPLOY}" != "true" ]; then \
 			echo "REMOTE_DEPLOY_BRANCH=${REMOTE_DEPLOY_BRANCH} is not the expected preprod git ref ${GIT_BRANCH_MAIN}"; \
 			exit 1; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -659,7 +659,7 @@ deploy-remote-preflight: config-minimal
 	done; \
 	echo "deploy-remote preflight ok for ${APP_DNS_TARGET}"
 
-deploy-remote: config-minimal deploy-remote-instance deploy-monitor-start deploy-remote-services deploy-remote-publish deploy-cdn-purge-cache deploy-delete-old deploy-monitor-wait
+deploy-remote: config-minimal deploy-remote-instance deploy-remote-services deploy-remote-publish deploy-cdn-purge-cache deploy-delete-old deploy-monitor
 
 deploy-docker-pull-base: deploy-remote-instance
 	@${MAKE} -C ${TOOLS_PATH} remote-docker-pull DOCKER_IMAGE=${BACKEND_NODE_IMAGE}

--- a/Makefile
+++ b/Makefile
@@ -631,7 +631,7 @@ deploy-remote-preflight: config-minimal
 			echo "GIT_BRANCH=${GIT_BRANCH} is not the expected preprod runtime label dev"; \
 			exit 1; \
 		fi; \
-		if [ "${REMOTE_DEPLOY_BRANCH}" != "${GIT_BRANCH_MAIN}" ] && [ "${ALLOW_NON_MAIN_DEV_DEPLOY}" != "true" ]; then \
+		if [ "${REMOTE_DEPLOY_BRANCH}" != "${GIT_BRANCH_MAIN}" ]; then \
 			echo "REMOTE_DEPLOY_BRANCH=${REMOTE_DEPLOY_BRANCH} is not the expected preprod git ref ${GIT_BRANCH_MAIN}"; \
 			exit 1; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -560,11 +560,21 @@ deploy-delete-old: ${DATAPREP_VERSION_FILE} ${DATA_VERSION_FILE}
 		GIT_BRANCH=${GIT_BRANCH} ${MAKEOVERRIDES}
 
 deploy-monitor:
-	@${MAKE} -C ${TOOLS_PATH} remote-install-monitor\
-		MONITOR_BUCKET=${MONITOR_BUCKET} MONITOR_DIR=${MONITOR_DIR}\
-		STORAGE_ACCESS_KEY=${TOOLS_STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${TOOLS_STORAGE_SECRET_KEY}\
-		NEW_RELIC_INGEST_KEY=${NEW_RELIC_INGEST_KEY} NEW_RELIC_API_KEY=${NEW_RELIC_API_KEY} NEW_RELIC_ACCOUNT_ID=${NEW_RELIC_ACCOUNT_ID}\
-		${MAKEOVERRIDES}
+	@${MAKE} deploy-monitor-start deploy-monitor-wait ${MAKEOVERRIDES}
+
+deploy-monitor-start:
+	@${MAKE} -C ${TOOLS_PATH} remote-install-monitor-start\
+			MONITOR_BUCKET=${MONITOR_BUCKET} MONITOR_DIR=${MONITOR_DIR}\
+			STORAGE_ACCESS_KEY=${TOOLS_STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${TOOLS_STORAGE_SECRET_KEY}\
+			NEW_RELIC_INGEST_KEY=${NEW_RELIC_INGEST_KEY} NEW_RELIC_API_KEY=${NEW_RELIC_API_KEY} NEW_RELIC_ACCOUNT_ID=${NEW_RELIC_ACCOUNT_ID}\
+			${MAKEOVERRIDES}
+
+deploy-monitor-wait:
+	@${MAKE} -C ${TOOLS_PATH} remote-install-monitor-wait\
+			MONITOR_BUCKET=${MONITOR_BUCKET} MONITOR_DIR=${MONITOR_DIR}\
+			STORAGE_ACCESS_KEY=${TOOLS_STORAGE_ACCESS_KEY} STORAGE_SECRET_KEY=${TOOLS_STORAGE_SECRET_KEY}\
+			NEW_RELIC_INGEST_KEY=${NEW_RELIC_INGEST_KEY} NEW_RELIC_API_KEY=${NEW_RELIC_API_KEY} NEW_RELIC_ACCOUNT_ID=${NEW_RELIC_ACCOUNT_ID}\
+			${MAKEOVERRIDES}
 
 deploy-cdn-purge-cache:
 	@${MAKE} -C ${TOOLS_PATH} cdn-cache-purge
@@ -649,7 +659,7 @@ deploy-remote-preflight: config-minimal
 	done; \
 	echo "deploy-remote preflight ok for ${APP_DNS_TARGET}"
 
-deploy-remote: config-minimal deploy-remote-instance deploy-remote-services deploy-remote-publish deploy-cdn-purge-cache deploy-delete-old deploy-monitor
+deploy-remote: config-minimal deploy-remote-instance deploy-monitor-start deploy-remote-services deploy-remote-publish deploy-cdn-purge-cache deploy-delete-old deploy-monitor-wait
 
 deploy-docker-pull-base: deploy-remote-instance
 	@${MAKE} -C ${TOOLS_PATH} remote-docker-pull DOCKER_IMAGE=${BACKEND_NODE_IMAGE}

--- a/packages/deces-backend/Makefile
+++ b/packages/deces-backend/Makefile
@@ -172,13 +172,14 @@ backend-start: backend-redis
 	@export EXEC_ENV=production; ${DC_BACKEND} up -d 2>&1 | grep -v orphan
 	@timeout=${BACKEND_TIMEOUT} ; ret=1 ;\
 		until [ "$$timeout" -le 0 -o "$$ret" -eq "0"  ] ; do\
-			(docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/version > /dev/null) ;\
+			(timeout 5s docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --connect-timeout 2 --max-time 4 --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/version > /dev/null) ;\
 			ret=$$? ;\
 			if [ "$$ret" -ne "0" ] ; then\
 				echo -e "try still $$timeout seconds to start backend before timeout" ;\
 			fi ;\
 			((timeout--)); sleep 1 ;\
 		done ;\
+	if [ "$$ret" -ne "0" ]; then docker logs --tail 200 ${APP_BACKEND} || true; fi ;\
 	echo -e "backend started in $$((BACKEND_TIMEOUT - timeout)) seconds"; exit $$ret
 
 backend-stop:

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -125,6 +125,7 @@ SSHOPTS=-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCoun
 # the runner injects a global ~/.ssh/config ProxyJump for SCW instances.
 NGINX_SSHOPTS=-F /dev/null -o ProxyJump=none -o StrictHostKeyChecking=no -i ${SSHKEY_PRIVATE}
 REMOTE_ACTION_MAKEOVERRIDES := $(filter-out CLOUD_SSHOPTS=% SSHKEY_PRIVATE=% SSHKEY=% SSHKEYNAME=% SSHID=% ${HOME}/.ssh/config ${HOME}/.ssh/% %/.ssh/%,$(MAKEOVERRIDES))
+MONITOR_INSTALL_TIMEOUT ?= 900
 
 tag                 := $(shell [ -f "/usr/bin/git" ] && ((git describe --tags 2>/dev/null || git rev-parse --short HEAD 2>/dev/null) | sed 's/-.*//' | sed 's#[^A-Za-z0-9_.-]#-#g'))
 VERSION 		:= $(shell cat tagfiles.${CLOUD_CLI}.version | xargs -I '{}' find {} -type f -not -name '*.tar.gz'  | sort | xargs cat | sha1sum - | sed 's/\(......\).*/\1/')
@@ -1358,20 +1359,47 @@ remote-install-root-aws-credentials:
 	@if [ ! -z "${STORAGE_ACCESS_KEY}" -a ! -z "${STORAGE_SECRET_KEY}" ];then\
 		H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
 		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
-		ssh ${SSHOPTS} $$U@$$H "sudo mkdir /root/.aws";\
+		ssh ${SSHOPTS} $$U@$$H "sudo mkdir -p /root/.aws";\
 		cat ${TOOLS_PATH}/.aws/config | ssh ${SSHOPTS} $$U@$$H "sudo tee /root/.aws/config > /dev/null";\
 		cat ${TOOLS_PATH}/.aws/credentials | sed "s/<AWS_ACCESS_KEY_ID>/${STORAGE_ACCESS_KEY}/;s/<AWS_SECRET_ACCESS_KEY>/${STORAGE_SECRET_KEY}/;" | ssh ${SSHOPTS} $$U@$$H "sudo tee /root/.aws/credentials > /dev/null";\
 	fi
 
-remote-install-monitor: remote-install-root-aws-credentials
+remote-install-monitor: remote-install-monitor-start remote-install-monitor-wait
+
+remote-install-monitor-start: remote-install-root-aws-credentials
 	@if [ ! -z "${NEW_RELIC_API_KEY}" -a ! -z "${NEW_RELIC_ACCOUNT_ID}" ];then\
 		H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
 		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
 		cat ${TOOLS_PATH}/fluent-bit/plugins.conf | ssh ${SSHOPTS} $$U@$$H "sudo tee /tmp/plugins.conf > /dev/null";\
 		cat ${TOOLS_PATH}/fluent-bit/fluent-bit.conf | sed "s/<NEW_RELIC_INGEST_KEY>/${NEW_RELIC_INGEST_KEY}/;s|<HTTPS_PROXY>|${remote_http_proxy}|;s|<MONITOR_BUCKET>|${MONITOR_BUCKET}|;s|<MONITOR_DIR>|${MONITOR_DIR}|" | ssh ${SSHOPTS} $$U@$$H "sudo tee /tmp/fluent-bit.conf > /dev/null";\
-		ssh ${SSHOPTS} $$U@$$H "(sudo systemctl stop unattended-upgrades;sleep 30;curl -Ls https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash && sudo HTTPS_PROXY=${remote_http_proxy} NEW_RELIC_API_KEY=${NEW_RELIC_API_KEY} NEW_RELIC_ACCOUNT_ID=${NEW_RELIC_ACCOUNT_ID} NEW_RELIC_REGION=EU /usr/local/bin/newrelic install -y && echo New Relic Installed) > .install-newrelic.log 2>&1 &";\
-		ssh ${SSHOPTS} $$U@$$H "(sudo systemctl stop unattended-upgrades;sleep 30;curl -s https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh; sudo mv /tmp/fluent-bit.conf /etc/fluent-bit/ && echo 'HOME=/root' | sudo tee /etc/default/fluent-bit && sudo systemctl daemon-reload && sudo systemctl restart fluent-bit && echo Fluent-bit installed) > .install-fluentbit.log 2>&1 &";\
-		ssh ${SSHOPTS} $$U@$$H "(sleep 3600;sudo systemctl start unattended-upgrades) > .install-reactivate-upgrades.log 2>&1 &";\
+		cat ${TOOLS_PATH}/scripts/deploy-monitor.sh | ssh ${SSHOPTS} $$U@$$H "cat > /tmp/matchid-remote-install-monitor.sh && chmod +x /tmp/matchid-remote-install-monitor.sh";\
+		ssh ${SSHOPTS} $$U@$$H "rm -f .install-monitor.status .install-monitor.running .install-monitor.log";\
+		ssh ${SSHOPTS} $$U@$$H "(touch .install-monitor.running; HTTPS_PROXY='${remote_http_proxy}' NEW_RELIC_API_KEY='${NEW_RELIC_API_KEY}' NEW_RELIC_ACCOUNT_ID='${NEW_RELIC_ACCOUNT_ID}' NEW_RELIC_REGION='EU' /tmp/matchid-remote-install-monitor.sh; ret=\$$?; rm -f .install-monitor.running; echo \$$ret > .install-monitor.status; exit \$$ret) > .install-monitor.log 2>&1 &";\
+		echo "monitor install started";\
+	fi
+
+remote-install-monitor-wait:
+	@if [ ! -z "${NEW_RELIC_API_KEY}" -a ! -z "${NEW_RELIC_ACCOUNT_ID}" ];then\
+		H=$$(tr -d '\r\n[:space:]' < ${CLOUD_HOST_FILE});\
+		U=$$(tr -d '\r\n[:space:]' < ${CLOUD_USER_FILE});\
+		timeout=${MONITOR_INSTALL_TIMEOUT}; status=running;\
+		while [ "$$timeout" -gt 0 ]; do\
+			status=$$(ssh ${SSHOPTS} $$U@$$H "if [ -f .install-monitor.status ]; then cat .install-monitor.status; elif [ -f .install-monitor.running ]; then echo running; else echo missing; fi" | tr -d '\r\n[:space:]');\
+			if [ "$$status" != "running" ]; then break; fi;\
+			sleep 5;\
+			timeout=$$((timeout - 5));\
+		done;\
+		if [ "$$status" = "running" ] || [ "$$status" = "missing" ] || [ -z "$$status" ]; then\
+			echo "monitor install did not complete (status=$$status)";\
+			ssh ${SSHOPTS} $$U@$$H "tail -120 .install-monitor.log" || true;\
+			exit 1;\
+		fi;\
+		if [ "$$status" != "0" ]; then\
+			echo "monitor install failed with status $$status";\
+			ssh ${SSHOPTS} $$U@$$H "tail -120 .install-monitor.log" || true;\
+			exit $$status;\
+		fi;\
+		ssh ${SSHOPTS} $$U@$$H "tail -40 .install-monitor.log" || true;\
 	fi
 
 cdn-cache-purge:

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -121,7 +121,7 @@ endif
 dummy		    := $(shell touch artifacts)
 include ./artifacts
 
-SSHOPTS=-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
+SSHOPTS=-o StrictHostKeyChecking=no -o ConnectTimeout=${SSH_CONNECT_TIMEOUT} -o ConnectionAttempts=1 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
 # Nginx publication must connect directly to the bastion/nginx host, even when
 # the runner injects a global ~/.ssh/config ProxyJump for SCW instances.
 NGINX_SSHOPTS=-F /dev/null -o ProxyJump=none -o StrictHostKeyChecking=no -i ${SSHKEY_PRIVATE}
@@ -447,12 +447,12 @@ ${CLOUD}-instance-wait-ssh: ${CLOUD_FIRST_USER_FILE} ${CLOUD_HOST_FILE}
 		(ssh-keygen -R $$HOST > /dev/null 2>&1) || true;\
 		timeout=${SSH_TIMEOUT} ; ret=1 ;\
 		until [ "$$timeout" -le 0 -o "$$ret" -eq "0"  ] ; do\
-			((ssh ${SSHOPTS} -o ConnectTimeout=${SSH_CONNECT_TIMEOUT} -o ConnectionAttempts=1 $$SSHUSER@$$HOST sleep 1) );\
+			((ssh ${SSHOPTS} $$SSHUSER@$$HOST sleep 1) );\
 			ret=$$? ; \
 			if [ "$$ret" -ne "0" ] ; then\
 				echo -en "\rwaiting for ssh service on ${CLOUD} instance - $$timeout" ; \
 				if [ ! -z "${VERBOSE}" ];then\
-					echo 'cmd: ssh ${SSHOPTS} -o ConnectTimeout=${SSH_CONNECT_TIMEOUT} -o ConnectionAttempts=1 '"$$SSHUSER@$$HOST"; \
+					echo 'cmd: ssh ${SSHOPTS} '"$$SSHUSER@$$HOST"; \
 				fi;\
 			fi ;\
 			((timeout--)); sleep 1 ; \

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -85,6 +85,7 @@ SSHKEY_PRIVATE = ${HOME}/.ssh/id_rsa_${APP_GROUP}
 SSHKEY = ${SSHKEY_PRIVATE}.pub
 SSHKEYNAME = ${TOOLS}
 SSH_TIMEOUT = 90
+SSH_CONNECT_TIMEOUT = 5
 
 export CURL_OPTS = --retry 5 --retry-delay 2 -A "GitHub Actions"
 
@@ -446,12 +447,12 @@ ${CLOUD}-instance-wait-ssh: ${CLOUD_FIRST_USER_FILE} ${CLOUD_HOST_FILE}
 		(ssh-keygen -R $$HOST > /dev/null 2>&1) || true;\
 		timeout=${SSH_TIMEOUT} ; ret=1 ;\
 		until [ "$$timeout" -le 0 -o "$$ret" -eq "0"  ] ; do\
-			((ssh ${SSHOPTS} $$SSHUSER@$$HOST sleep 1) );\
+			((ssh ${SSHOPTS} -o ConnectTimeout=${SSH_CONNECT_TIMEOUT} -o ConnectionAttempts=1 $$SSHUSER@$$HOST sleep 1) );\
 			ret=$$? ; \
 			if [ "$$ret" -ne "0" ] ; then\
 				echo -en "\rwaiting for ssh service on ${CLOUD} instance - $$timeout" ; \
 				if [ ! -z "${VERBOSE}" ];then\
-					echo 'cmd: ssh ${SSHOPTS} -o ConnectTimeout=1 '"$$SSHUSER@$$HOST"; \
+					echo 'cmd: ssh ${SSHOPTS} -o ConnectTimeout=${SSH_CONNECT_TIMEOUT} -o ConnectionAttempts=1 '"$$SSHUSER@$$HOST"; \
 				fi;\
 			fi ;\
 			((timeout--)); sleep 1 ; \

--- a/packages/tools/scripts/deploy-monitor.sh
+++ b/packages/tools/scripts/deploy-monitor.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NEW_RELIC_REGION="${NEW_RELIC_REGION:-EU}"
+MONITOR_APT_GRACE_SECONDS="${MONITOR_APT_GRACE_SECONDS:-30}"
+
+require_env() {
+	local name="$1"
+	if [ -z "${!name:-}" ]; then
+		echo "error: ${name} is required" >&2
+		exit 1
+	fi
+}
+
+restart_unattended_upgrades() {
+	sudo systemctl start unattended-upgrades >/dev/null 2>&1 || true
+}
+
+install_newrelic() {
+	echo "Installing New Relic CLI and integrations"
+	curl -fsSL https://download.newrelic.com/install/newrelic-cli/scripts/install.sh | bash
+	sudo env \
+		HTTPS_PROXY="${HTTPS_PROXY:-}" \
+		NEW_RELIC_API_KEY="${NEW_RELIC_API_KEY}" \
+		NEW_RELIC_ACCOUNT_ID="${NEW_RELIC_ACCOUNT_ID}" \
+		NEW_RELIC_REGION="${NEW_RELIC_REGION}" \
+		/usr/local/bin/newrelic install -y
+
+	local discovered="/etc/newrelic-infra/logging.d/discovered.yml"
+	if sudo test -e "${discovered}" && ! sudo test -s "${discovered}"; then
+		echo "Disabling empty New Relic log discovery config"
+		sudo mv "${discovered}" "${discovered}.disabled"
+	fi
+
+	sudo systemctl enable newrelic-infra
+	sudo systemctl restart newrelic-infra
+	sudo systemctl is-active --quiet newrelic-infra
+	echo "New Relic Installed"
+}
+
+install_fluentbit() {
+	echo "Installing Fluent Bit"
+	curl -fsSL https://raw.githubusercontent.com/fluent/fluent-bit/master/install.sh | sh
+	sudo install -m 0644 /tmp/fluent-bit.conf /etc/fluent-bit/fluent-bit.conf
+	if [ -s /tmp/plugins.conf ]; then
+		sudo install -m 0644 /tmp/plugins.conf /etc/fluent-bit/plugins.conf
+	fi
+	echo 'HOME=/root' | sudo tee /etc/default/fluent-bit >/dev/null
+	sudo systemctl daemon-reload
+	sudo systemctl enable fluent-bit
+	sudo systemctl restart fluent-bit
+	sudo systemctl is-active --quiet fluent-bit
+	echo "Fluent-bit installed"
+}
+
+require_env NEW_RELIC_API_KEY
+require_env NEW_RELIC_ACCOUNT_ID
+
+trap restart_unattended_upgrades EXIT
+sudo systemctl stop unattended-upgrades >/dev/null 2>&1 || true
+sleep "${MONITOR_APT_GRACE_SECONDS}"
+
+install_newrelic 2>&1 | tee "${HOME}/.install-newrelic.log"
+install_fluentbit 2>&1 | tee "${HOME}/.install-fluentbit.log"
+echo "Monitor installed"


### PR DESCRIPTION
## Summary
- split deploy-monitor into start/wait targets
- run New Relic then Fluent Bit sequentially inside one remote background job
- fail deploy completion if monitor install fails or times out

## Test plan
- bash -n packages/tools/scripts/deploy-monitor.sh
- make -n deploy-monitor with dummy monitor/New Relic variables

Closes #34

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Monitor install now runs as a two-phase start+wait flow with background execution, progress/status indicators, and install logs.
  * Installer now sets up monitoring agents (New Relic + Fluent Bit), ensures required credentials, and manages service restarts.

* **Chores / Reliability**
  * Added timeouts and SSH/connect tuning to prevent indefinite waits.
  * CI deploy preflight can bypass main-branch restriction when allowed and forwards the chosen branch into deploy steps.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matchID-project/matchID/pull/51)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->