### PR TITLE
experiment(k8s): scaffold k3s-local + Kapsule poc overlays for matchID

### DIFF
--- a/.github/workflows/k8s-smoke.yml
+++ b/.github/workflows/k8s-smoke.yml
@@ -83,20 +83,34 @@ jobs:
           kubectl apply -k deploy/k8s/overlays/local/
           kubectl -n matchid get all
 
-      - name: Wait for deployments
+      - name: Background diagnostics (events + pods every 30s)
         run: |
-          set +e
-          kubectl -n matchid wait --for=condition=Available --timeout=8m \
+          # Background poller — emits events and pod summary every 30s so we
+          # see what's wrong even if the next step ends up cancelled.
+          (
+            while true; do
+              echo "===== $(date -u +%H:%M:%S) pods ====="
+              kubectl -n matchid get pods -o wide 2>&1 || true
+              echo "===== events (tail 20) ====="
+              kubectl -n matchid get events --sort-by=.lastTimestamp 2>&1 | tail -20 || true
+              sleep 30
+            done
+          ) &
+          echo "POLLER_PID=$!" >> "$GITHUB_ENV"
+
+      - name: Wait for elasticsearch first (deces-backend depends on it)
+        run: |
+          kubectl -n matchid rollout status statefulset/elasticsearch --timeout=6m
+
+      - name: Wait for deces-backend / deces-ui
+        run: |
+          kubectl -n matchid wait --for=condition=Available --timeout=4m \
             deploy/deces-backend deploy/deces-ui
-          BACK_READY=$?
-          kubectl -n matchid rollout status statefulset/elasticsearch --timeout=8m
-          ES_READY=$?
-          if [ $BACK_READY -ne 0 ] || [ $ES_READY -ne 0 ]; then
-            echo "::warning::workloads did not all reach ready — printing diagnostics"
-            kubectl -n matchid get events --sort-by=.lastTimestamp | tail -40
-            kubectl -n matchid describe pod -l app.kubernetes.io/part-of=matchid | tail -80
-            exit 1
-          fi
+
+      - name: Stop background poller
+        if: always()
+        run: |
+          [ -n "${POLLER_PID:-}" ] && kill "$POLLER_PID" 2>/dev/null || true
 
       - name: Smoke health endpoints
         run: |
@@ -110,7 +124,7 @@ jobs:
           curl -fsS -m 5 http://localhost:8083/ | head -c 200
 
       - name: Diagnostics on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           kubectl -n matchid get pods -o wide
           kubectl -n matchid describe pods | tail -120
@@ -190,7 +204,7 @@ jobs:
           curl -fsSk -m 8 -H "Host: matchid-poc.matchid.io" "http://$TRAEFIK_LB/deces/api/v1/healthcheck"
 
       - name: Diagnostics on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           kubectl -n matchid get pods -o wide
           kubectl -n matchid describe pods | tail -120

--- a/.github/workflows/k8s-smoke.yml
+++ b/.github/workflows/k8s-smoke.yml
@@ -98,7 +98,11 @@ jobs:
           ) &
           echo "POLLER_PID=$!" >> "$GITHUB_ENV"
 
-      - name: Wait for elasticsearch first (deces-backend depends on it)
+      - name: Wait for redis (BullMQ broker for deces-backend)
+        run: |
+          kubectl -n matchid wait --for=condition=Available --timeout=2m deploy/redis
+
+      - name: Wait for elasticsearch (deces-backend depends on it)
         run: |
           kubectl -n matchid rollout status statefulset/elasticsearch --timeout=6m
 

--- a/.github/workflows/k8s-smoke.yml
+++ b/.github/workflows/k8s-smoke.yml
@@ -1,0 +1,197 @@
+# K8s smoke workflow — local k3d on push/PR + manual dispatch to Kapsule POC.
+#
+# Required GH secrets (already present unless noted):
+#   - SCW_ACCESS_KEY        (existing)
+#   - SCW_SECRET_TOKEN      (existing)
+#   - SCW_ORGANIZATION_ID   (NEW — Scaleway org UUID)
+#   - SCW_POC_PROJECT_ID    (NEW — PoCs project UUID)
+#   - SCW_POC_CLUSTER_ID    (NEW — Kapsule cluster `poc` UUID)
+#
+# Set them via:
+#   printf '%s' "<org-uuid>" | gh secret set SCW_ORGANIZATION_ID -R matchID-project/matchID
+#   printf '%s' "<poc-project-uuid>" | gh secret set SCW_POC_PROJECT_ID -R matchID-project/matchID
+#   printf '%s' "<cluster-uuid>" | gh secret set SCW_POC_CLUSTER_ID -R matchID-project/matchID
+# (values live in ~/src/matchID/matchID/artifacts — never echo them on stdout).
+#
+# The smoke-local job needs nothing extra and runs free on the ubuntu-latest runner.
+name: K8s smoke
+
+on:
+  push:
+    branches:
+      - experiment/k8s
+    paths:
+      - 'deploy/k8s/**'
+      - '.github/workflows/k8s-smoke.yml'
+  pull_request:
+    paths:
+      - 'deploy/k8s/**'
+      - '.github/workflows/k8s-smoke.yml'
+  workflow_dispatch:
+    inputs:
+      target:
+        description: Cluster target
+        required: true
+        default: local
+        type: choice
+        options:
+          - local
+          - poc
+
+concurrency:
+  group: k8s-smoke-${{ github.ref }}-${{ github.event.inputs.target || 'local' }}
+  cancel-in-progress: true
+
+jobs:
+  smoke-local:
+    name: smoke-local (k3s in runner)
+    if: github.event_name != 'workflow_dispatch' || github.event.inputs.target == 'local'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install k3d
+        run: |
+          set -euo pipefail
+          curl -sfL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh \
+            | TAG=v5.7.4 bash
+          k3d version
+
+      - name: Create k3d cluster
+        run: |
+          k3d cluster create matchid-ci \
+            --port "8083:30083@loadbalancer" \
+            --port "8080:30080@loadbalancer" \
+            --wait
+          kubectl wait --for=condition=Ready node --all --timeout=120s
+
+      - name: Wait for Traefik CRDs
+        run: |
+          for _ in $(seq 1 60); do
+            kubectl get crd ingressroutes.traefik.io >/dev/null 2>&1 && exit 0
+            sleep 2
+          done
+          echo "Traefik CRDs did not land within 120s" >&2
+          kubectl get pods -A
+          exit 1
+
+      - name: Apply local overlay
+        run: |
+          kubectl apply -k deploy/k8s/overlays/local/
+          kubectl -n matchid get all
+
+      - name: Wait for deployments
+        run: |
+          set +e
+          kubectl -n matchid wait --for=condition=Available --timeout=8m \
+            deploy/deces-backend deploy/deces-ui
+          BACK_READY=$?
+          kubectl -n matchid rollout status statefulset/elasticsearch --timeout=8m
+          ES_READY=$?
+          if [ $BACK_READY -ne 0 ] || [ $ES_READY -ne 0 ]; then
+            echo "::warning::workloads did not all reach ready — printing diagnostics"
+            kubectl -n matchid get events --sort-by=.lastTimestamp | tail -40
+            kubectl -n matchid describe pod -l app.kubernetes.io/part-of=matchid | tail -80
+            exit 1
+          fi
+
+      - name: Smoke health endpoints
+        run: |
+          set -e
+          # via NodePort exposed by k3d loadbalancer
+          for _ in $(seq 1 30); do
+            curl -fsS -m 5 http://localhost:8080/deces/api/v1/healthcheck && break
+            sleep 4
+          done
+          curl -fsS -m 5 http://localhost:8080/deces/api/v1/healthcheck
+          curl -fsS -m 5 http://localhost:8083/ | head -c 200
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n matchid get pods -o wide
+          kubectl -n matchid describe pods | tail -120
+          kubectl -n matchid logs -l app.kubernetes.io/part-of=matchid --all-containers=true --tail=200 || true
+
+      - name: Tear down
+        if: always()
+        run: |
+          k3d cluster delete matchid-ci || true
+
+  smoke-poc:
+    name: smoke-poc (Scaleway Kapsule)
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.target == 'poc'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    env:
+      SCW_ACCESS_KEY: ${{ secrets.SCW_ACCESS_KEY }}
+      SCW_SECRET_KEY: ${{ secrets.SCW_SECRET_TOKEN }}
+      SCW_DEFAULT_ORGANIZATION_ID: ${{ secrets.SCW_ORGANIZATION_ID }}
+      SCW_DEFAULT_PROJECT_ID: ${{ secrets.SCW_POC_PROJECT_ID }}
+      SCW_DEFAULT_REGION: fr-par
+      SCW_POC_CLUSTER_ID: ${{ secrets.SCW_POC_CLUSTER_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install scw + kubectl
+        run: |
+          set -euo pipefail
+          curl -sL "https://github.com/scaleway/scaleway-cli/releases/download/v2.34.0/scaleway-cli_2.34.0_linux_amd64" \
+            -o /usr/local/bin/scw && chmod +x /usr/local/bin/scw
+          scw version
+          kubectl version --client=true
+
+      - name: Fetch kubeconfig
+        run: |
+          test -n "$SCW_POC_CLUSTER_ID"
+          mkdir -p "$HOME/.kube"
+          scw k8s kubeconfig get "$SCW_POC_CLUSTER_ID" > "$HOME/.kube/config"
+          chmod 600 "$HOME/.kube/config"
+          kubectl get ns matchid
+
+      - name: Apply poc overlay
+        run: |
+          kubectl apply -k deploy/k8s/overlays/poc/
+          kubectl -n matchid get all
+
+      - name: Wait for deployments
+        run: |
+          set +e
+          kubectl -n matchid wait --for=condition=Available --timeout=10m \
+            deploy/deces-backend deploy/deces-ui
+          B=$?
+          kubectl -n matchid rollout status statefulset/elasticsearch --timeout=10m
+          E=$?
+          if [ $B -ne 0 ] || [ $E -ne 0 ]; then
+            kubectl -n matchid get events --sort-by=.lastTimestamp | tail -40
+            kubectl -n matchid describe pod -l app.kubernetes.io/part-of=matchid | tail -80
+            exit 1
+          fi
+
+      - name: Smoke via IngressRoute
+        run: |
+          # The poc overlay publishes an IngressRoute. We don't TLS-validate here.
+          # Find the ingress public endpoint via the LoadBalancer service Traefik exposes.
+          TRAEFIK_LB=$(kubectl -n kube-system get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+          if [ -z "$TRAEFIK_LB" ]; then
+            echo "::warning::No Traefik LB IP yet — falling back to port-forward smoke"
+            kubectl -n matchid port-forward svc/deces-backend 8080:8080 &
+            PF=$!
+            sleep 4
+            curl -fsS -m 5 http://localhost:8080/deces/api/v1/healthcheck
+            kill $PF
+            exit 0
+          fi
+          curl -fsSk -m 8 -H "Host: matchid-poc.matchid.io" "http://$TRAEFIK_LB/deces/api/v1/healthcheck"
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          kubectl -n matchid get pods -o wide
+          kubectl -n matchid describe pods | tail -120
+          kubectl -n matchid logs -l app.kubernetes.io/part-of=matchid --all-containers=true --tail=200 || true

--- a/deploy/k8s/K8S_READINESS_AUDIT.md
+++ b/deploy/k8s/K8S_READINESS_AUDIT.md
@@ -1,0 +1,349 @@
+# matchID Kubernetes Readiness Audit
+
+**Audit Date:** 2026-05-16  
+**Branch:** experiment/k8s  
+**Scope:** Architectural patterns that break under Kubernetes (stateless pods, ephemeral filesystems, horizontal scaling, rolling updates)
+
+---
+
+## Executive Summary
+
+Audit identified **8 P0 findings** (block even 1-replica deployment), **6 P1 findings** (block scaling >1), and **4 P2 findings** (nice-to-have). The three most critical issues are:
+
+1. **OTP in-memory store** (`mail.ts:60`) — loses all OTPs on pod restart or cross-pod routing
+2. **Rate-limiting via IP-based maps** (`authentification.ts:4-5`) — routing to different pods bypasses bans
+3. **Job state tracking in arrays** (`processStream.ts:57-60`) — lost on pod restart, breaks bulk operations
+
+Blocking issues concentrate in:
+- `packages/deces-backend/src/` (in-memory state)
+- `packages/deces-backend/src/processStream.ts` (file I/O, job tracking)
+- Nginx config (`ip_hash` sticky sessions)
+- Elasticsearch (single-node, no HA)
+
+---
+
+## P0 Findings (Blocks 1-replica or deployment stability)
+
+### 1. OTP Store — In-Memory Ephemeral State
+
+**Location:** `packages/deces-backend/src/mail.ts:60`
+
+```typescript
+const OTP: Record<string, OTPEntry> = {};
+```
+
+**Why it breaks:** OTP codes and rate-limit counters live only in pod RAM. Pod restart = all OTPs lost. With 2+ replicas, user OTP sent to pod-A; cross-pod routing sends validation to pod-B → mismatch.
+
+**Proposed Fix:** Move to Redis (shared ephemeral store) or DB (persistent). Use `ioredis` library. Store structure: `otp:{email}` → `{code, lastSendTime, recentSendCount}`. TTL: 6 hours.  
+**Effort:** M (requires schema, middleware integration)  
+**Priority:** P0 (breaks 2-replica auth flow immediately)
+
+---
+
+### 2. IP-Based Rate Limiting & Ban Tracking
+
+**Location:** `packages/deces-backend/src/authentification.ts:4-5, 19-36`
+
+```typescript
+const bannedIP: any = {};
+const toBeBannedIP: any = {};
+```
+
+**Why it breaks:** Tracks request counts per IP in memory. Pod restart clears bans. With load balancer, same IP hits different pods → no shared rate-limit state → bypass ban.
+
+**Proposed Fix:** Move to Redis with pattern `ratelimit:{ip}` (counter with TTL 1h) and `banned:{ip}` (TTL 4h). Requires replacing setTimeout with Redis key expiry.  
+**Effort:** M (refactor auth middleware, handle Redis failures gracefully)  
+**Priority:** P0 (trivial abuse vector once scaled)
+
+---
+
+### 3. Job State Arrays in Memory
+
+**Location:** `packages/deces-backend/src/processStream.ts:57-60`
+
+```typescript
+const stopJob: string[] = [];
+const stopJobReason: StopJobReason[] = [];
+const inputsArray: JobInput[] = [];
+```
+
+**Why it breaks:** Tracks which jobs are stopped and where input files are. Pod restart = arrays lost. BullMQ queue survives on Redis, but job metadata (stop state, input file paths) lives only in pod RAM → resuming job on different pod fails.
+
+**Proposed Fix:** Persist stop flags and file metadata in Redis (`job:{id}:stopped`, `job:{id}:inputFile`). Replace arrays with Redis hashes.  
+**Effort:** M (refactor ProcessStream worker, add Redis checks before file ops)  
+**Priority:** P0 (bulk jobs fail mysteriously on restart)
+
+---
+
+### 4. Filesystem as Primary Job Storage
+
+**Location:** `packages/deces-backend/src/processStream.ts:177, 473, 539, 543`
+
+```typescript
+fs.createWriteStream(`${process.env.JOBS}/${jobId}.out.enc`)
+fs.createWriteStream(`${process.env.JOBS}/${jobId}.in.enc`)
+fs.statSync(`${process.env.JOBS}/${jobId}.out.enc`)
+fs.createReadStream(`${process.env.JOBS}/${jobId}.out.enc`)
+```
+
+**Why it breaks:** Encrypted job files (.in.enc, .out.enc) written to `$JOBS` env-var path. In K8s, no PVC = ephemeral emptyDir → files lost on pod restart, blocking result retrieval. With PVC, shared mount required, but init container must ensure mount readiness.
+
+**Proposed Fix:** Use PVC for `$JOBS` directory (ReadWriteOnce or ReadWriteMany). Add init-container to verify mount. Or: stream results directly to S3/MinIO, skip local FS.  
+**Effort:** M (PVC requires StatefulSet; S3 requires credentials + SDK)  
+**Priority:** P0 (job results inaccessible after pod restart)
+
+---
+
+### 5. Proofs Directory as Runtime State
+
+**Location:** `packages/deces-backend/src/controllers/search.controller.ts:394-405`, `updatedIds.ts:33-43`
+
+```typescript
+const dir = `${process.env.PROOFS}/${id as string}`;
+fs.readFileSync(jsonFile, 'utf8')
+```
+
+**Why it breaks:** User-submitted proofs (PDFs) and update JSONs written to `$PROOFS`. No PVC = lost on restart. Loaded once at startup into `updatedFields` global, so new proofs uploaded during runtime aren't visible until reload.
+
+**Proposed Fix:** Use PVC for `$PROOFS` (ReadWriteMany if multi-replica). Add file-watcher or reload mechanism. Or: store proofs in DB/S3.  
+**Effort:** M (PVC + init-container, or DB schema redesign)  
+**Priority:** P0 (user corrections lost, uploaded proofs inaccessible)
+
+---
+
+### 6. Cached Version Info — Stale on Restart
+
+**Location:** `packages/deces-backend/src/controllers/status.controller.ts:11-14`
+
+```typescript
+let uniqRecordsCount: number;
+let lastDataset: string;
+let lastRecordDate: string;
+let updateDate: string;
+```
+
+**Why it breaks:** Cached once at first request, never refreshed. Pod restart re-caches. Across replicas, each pod has different cached values → inconsistent API responses.
+
+**Proposed Fix:** Move to Redis cache or query ES every time (performance tradeoff). Or: accept replicas returning different values (document eventual-consistency contract).  
+**Effort:** S (add Redis getter or remove cache logic)  
+**Priority:** P0 (API consistency, though not data loss)
+
+---
+
+### 7. Updated Records Loaded Once at Module Load
+
+**Location:** `packages/deces-backend/src/updatedIds.ts:31-44`
+
+```typescript
+const rawData: any = {};
+const jsonFiles = walk(`${process.env.PROOFS}`)
+export const updatedFields: any = Object.keys(rawData).length ? rawData : {};
+```
+
+**Why it breaks:** Walked from disk at startup. Any proofs added post-startup won't appear in API until pod restart. No multi-pod sync mechanism.
+
+**Proposed Fix:** Add file watcher (chokidar) to hot-reload `updatedFields` on file change, or query DB on-demand.  
+**Effort:** M (add watcher + thread-safe updates)  
+**Priority:** P0 (real-time data loss for user submissions)
+
+---
+
+### 8. Elasticsearch Single-Node, No HA
+
+**Location:** `packages/deces-backend/src/elasticsearch.ts:5`, `deploy/k8s/base/elasticsearch.statefulset.yaml`
+
+```typescript
+const config: ClientOptions = {
+  node: 'http://elasticsearch:9200',
+};
+```
+
+**Why it breaks:** Single node. Pod failure = data unavailable. No replication, no failover. Current StatefulSet has `replicas: 1`.
+
+**Proposed Fix:** Scale ES to 3-node cluster (StatefulSet replicas: 3), configure master/data roles, add persistent volume per node.  
+**Effort:** L (complex configuration, requires PV provisioning, monitoring)  
+**Priority:** P0 (data availability SLA)
+
+---
+
+## P1 Findings (Blocks scaling >1 replica)
+
+### 1. Sticky Session via Nginx ip_hash
+
+**Location:** `packages/tools/nginx/matchid-deces-ui-dev-upstream.conf:2`
+
+```nginx
+upstream matchid-deces-ui-dev {
+  ip_hash;
+  server 51.158.99.108:8083;
+}
+```
+
+**Why it breaks:** Production K8s uses load balancer (not nginx upstream). `ip_hash` tied to old SCW setup. With >1 backend replica and session state (login, upload chunks), client needs sticky routing. K8s requires Session Affinity at Service level or JWT (stateless).
+
+**Proposed Fix:** Remove `ip_hash` from nginx. Use K8s Service `sessionAffinity: ClientIP` (coarse-grained) or move to JWT-only auth (stateless).  
+**Effort:** S (if JWT-based auth already in place; else M for session migration)  
+**Priority:** P1 (multi-pod routing will randomly fail upload/login)
+
+---
+
+### 2. Nginx Config Bake-In of Env Variables
+
+**Location:** `packages/deces-ui/nginx/nginx-run.template` (all `<PLACEHOLDER>` vars)
+
+```nginx
+limit_req_zone $<API_USER_SCOPE> zone=app:10m rate=30r/s;
+...
+add_header Content-Security-Policy "<NGINX_CSP>";
+```
+
+**Why it breaks:** Entrypoint script should template-substitute `<API_USER_SCOPE>`, `<NGINX_CSP>`, etc. at pod start. If vars are baked at build-time, changing them requires rebuild.
+
+**Proposed Fix:** Add entrypoint.sh that `envsubst` on `nginx-run.template` → write to `/etc/nginx/nginx.conf` before starting nginx. Pass templated file as ConfigMap.  
+**Effort:** S (shell script + Dockerfile CMD change)  
+**Priority:** P1 (config changes require rebuild+push, slow feedback)
+
+---
+
+### 3. BullMQ Queue Persistence Tied to Redis Host
+
+**Location:** `packages/deces-backend/src/processStream.ts:61-71`
+
+```typescript
+const jobQueue = new Queue('jobs', {
+  connection: { host: 'redis' }
+});
+const chunkQueue = new Queue('chunks', {
+  connection: { host: 'redis' }
+});
+```
+
+**Why it breaks:** Hardcoded `host: 'redis'` assumes K8s Service named `redis`. No fallback. If Redis pod restarts slowly, job queue is stuck.
+
+**Proposed Fix:** Use env var `REDIS_HOST` (default 'redis'), add startup check (readiness probe) for Redis availability.  
+**Effort:** XS (one-line change)  
+**Priority:** P1 (intermittent failures if Redis becomes unreachable)
+
+---
+
+### 4. No Request Timeout/Cancellation for Long Jobs
+
+**Location:** `packages/deces-backend/src/processStream.ts:159-231` (processCsv)
+
+**Why it breaks:** Large file processing can take hours. No timeout mechanism. Rolling update kills pods → job left orphaned (BullMQ will retry on next poll). Chunk Worker has no circuit-breaker.
+
+**Proposed Fix:** Add `job.progress()` heartbeat, set BullMQ job timeout, add graceful shutdown handler to mark in-progress jobs for retry.  
+**Effort:** M (integrate job heartbeat, signal handlers)  
+**Priority:** P1 (rolling updates will orphan long jobs)
+
+---
+
+### 5. No Kubernetes Probes Configuration
+
+**Location:** `deploy/k8s/base/deces-backend.deployment.yaml:50-63` (readiness/liveness OK, but no startup probe)
+
+**Why it breaks:** Deployment has readiness/liveness but no startup probe. If backend takes >60s to become ready (e.g., Elasticsearch slow to connect), liveness probe kills pod before it's ready.
+
+**Proposed Fix:** Add `startupProbe` with high `failureThreshold` (e.g., 30 * 10s = 300s tolerance).  
+**Effort:** XS (YAML field addition)  
+**Priority:** P1 (slow startups trigger crash loop)
+
+---
+
+### 6. No Resource Requests for Workers
+
+**Location:** `packages/deces-backend/src/processStream.ts:269-287` (Worker inline, no K8s Job abstraction)
+
+**Why it breaks:** Chunk worker created as background process in Deployment, not K8s Job/CronJob. Consumes resources untracked. No separate scaling. If worker crashes, Deployment pod restart, but long-running job is lost.
+
+**Proposed Fix:** Move chunk/job processing to separate K8s Job or long-running Deployment with worker-specific resources. Or: use Lambda/Knative for serverless scaling.  
+**Effort:** L (refactor worker model, K8s Job integration)  
+**Priority:** P1 (resource starvation, no observability)
+
+---
+
+## P2 Findings (Nice-to-have, non-blocking)
+
+### 1. User Database File Persistence
+
+**Location:** `packages/deces-backend/src/userDB.ts` (assumed file-based, not verified in read)
+
+**Why it breaks:** If user DB is file-based (`DB_JSON=data/userDB.json`), no PVC = data lost. If it's real DB, this is non-issue.
+
+**Proposed Fix:** Verify and document userDB backing store. If file-based, use PVC or migrate to Postgres.  
+**Effort:** S (once clarified)  
+**Priority:** P2 (user accounts relatively stable, but good hygiene)
+
+---
+
+### 2. Logging to File Only
+
+**Location:** `packages/deces-backend/src/logger.ts` (console output, but loggerStream used throughout)
+
+**Why it breaks:** Winston logs to console (OK). But code calls `loggerStream.write()` directly in many places. If `loggerStream` is a file transport, logs lost on pod restart. Missing central logging.
+
+**Proposed Fix:** Use Winston file + syslog/ELK sink. Or: remove file logging, use stdout only (K8s native).  
+**Effort:** S (Winston config change + remove file transport)  
+**Priority:** P2 (debugging harder, but audit logs recoverable from ES)
+
+---
+
+### 3. No Graceful Shutdown for File Streams
+
+**Location:** `packages/deces-backend/src/processStream.ts` (streams piped, but no SIGTERM handler)
+
+**Why it breaks:** Pod receives SIGTERM during stream processing. No drain/cancel logic. Partial file writes. Not data-loss in bulk (BullMQ will retry), but messy.
+
+**Proposed Fix:** Add process-level SIGTERM handler to gracefully cancel in-flight streams.  
+**Effort:** S (signal handler + stream.destroy() calls)  
+**Priority:** P2 (mitigated by BullMQ retry, but cleaner)
+
+---
+
+### 4. Encryption IV Reuse
+
+**Location:** `packages/deces-backend/src/processStream.ts:52`
+
+```typescript
+const encryptioniv = crypto.randomBytes(16);
+```
+
+**Why it breaks:** IV generated once per pod start, reused for all job encryptions. Same IV + same key = weak. Pod restart generates new IV, but old files can't decrypt.
+
+**Proposed Fix:** Generate unique IV per job, store in metadata (or derive from job ID). Use authenticated encryption (aes-256-gcm, not cbc).  
+**Effort:** M (crypto refactor)  
+**Priority:** P2 (security concern, not K8s-specific)
+
+---
+
+## Summary Table
+
+| P0 | 8 | OTP store, rate-limit maps, job arrays, JOBS FS, PROOFS FS, cached version, updated records, ES single-node |
+|----|------|---|
+| P1 | 6 | Sticky sessions, nginx config bake-in, Redis hardcoding, job timeouts, no startup probe, no worker Jobs |
+| P2 | 4 | User DB, logging, stream shutdown, IV reuse |
+
+**Total effort to K8s-ready:** ~6-8 weeks (assuming 1 dev, parallelizable into P0 = 2 weeks + P1 = 2 weeks + P2 = 1 week).
+
+---
+
+## Recommended Sequencing
+
+1. **Week 1-2 (P0 Data Loss):** OTP → Redis, rate-limit → Redis, job arrays → Redis, JOBS/PROOFS → PVC or S3, ES → 3-node cluster.
+2. **Week 2-3 (P1 Scaling):** Sticky sessions (Service affinity), nginx entrypoint, Redis env vars, startup probe.
+3. **Week 3+ (P1 Robustness):** Job timeouts, worker isolation, stream graceful shutdown.
+4. **P2:** Logging, encryption, user DB.
+
+---
+
+## Out of Scope
+
+- Surch swap (covered by EXPERIMENT_SURCH.md)
+- TLS / cert-manager wiring
+- Helm vs Kustomize debate
+- Performance tuning
+
+---
+
+**Audit completed by:** Claude AI  
+**Branch:** experiment/k8s

--- a/deploy/k8s/Makefile
+++ b/deploy/k8s/Makefile
@@ -1,0 +1,71 @@
+# Make targets for the matchID k8s scaffold.
+# Intentionally minimal — no cross-talk with the root Makefile, no
+# tags/version logic. Drive locally with:
+#   make -C deploy/k8s k3d-up
+#   make -C deploy/k8s apply-local
+#   make -C deploy/k8s port-forward
+
+CLUSTER_NAME ?= matchid
+KUBE_CTX     ?= k3d-$(CLUSTER_NAME)
+NAMESPACE    ?= matchid
+UI_LOCAL_PORT ?= 8083
+BACKEND_LOCAL_PORT ?= 8080
+
+.PHONY: help k3d-up k3d-down apply-local apply-poc port-forward logs status
+
+help:
+	@echo "matchID k8s — local k3s scaffold"
+	@echo ""
+	@echo "  make k3d-up           Create a k3d cluster '$(CLUSTER_NAME)' with NodePort mappings"
+	@echo "  make k3d-down         Tear the k3d cluster down"
+	@echo "  make apply-local      kubectl apply -k overlays/local/  (k3d / k3s-local)"
+	@echo "  make apply-poc        kubectl apply -k overlays/poc/    (Scaleway Kapsule poc)"
+	@echo "  make port-forward     Port-forward UI:$(UI_LOCAL_PORT) and backend:$(BACKEND_LOCAL_PORT)"
+	@echo "  make logs             Tail logs from all matchid pods"
+	@echo "  make status           Show namespace, pods, services, PVCs"
+
+k3d-up:
+	@command -v k3d >/dev/null 2>&1 || { \
+	  echo "k3d not installed. Install:"; \
+	  echo "  curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash"; \
+	  exit 1; }
+	k3d cluster create $(CLUSTER_NAME) \
+	  --port "$(UI_LOCAL_PORT):30083@loadbalancer" \
+	  --port "$(BACKEND_LOCAL_PORT):30080@loadbalancer" \
+	  --wait
+
+k3d-down:
+	k3d cluster delete $(CLUSTER_NAME)
+
+apply-local:
+	kubectl --context $(KUBE_CTX) apply -k overlays/local/
+
+apply-poc:
+	@if [ -z "$$KUBECONFIG" ]; then \
+	  echo "ERROR: KUBECONFIG not set. Run: export KUBECONFIG=\$$(scw k8s kubeconfig get poc | grep KUBECONFIG | cut -d= -f2)"; \
+	  exit 1; \
+	fi
+	kubectl apply -k overlays/poc/
+
+port-forward:
+	@echo "deces-ui  → http://localhost:$(UI_LOCAL_PORT)"
+	@echo "deces-api → http://localhost:$(BACKEND_LOCAL_PORT)"
+	@kubectl --context $(KUBE_CTX) -n $(NAMESPACE) port-forward svc/deces-ui $(UI_LOCAL_PORT):8083 & \
+	kubectl --context $(KUBE_CTX) -n $(NAMESPACE) port-forward svc/deces-backend $(BACKEND_LOCAL_PORT):8080 ; \
+	wait
+
+logs:
+	kubectl --context $(KUBE_CTX) -n $(NAMESPACE) logs -l app.kubernetes.io/part-of=matchid --all-containers=true --tail=200 -f
+
+status:
+	@echo "--- namespace ---"
+	@kubectl --context $(KUBE_CTX) get ns $(NAMESPACE)
+	@echo ""
+	@echo "--- pods ---"
+	@kubectl --context $(KUBE_CTX) -n $(NAMESPACE) get pods -o wide
+	@echo ""
+	@echo "--- services ---"
+	@kubectl --context $(KUBE_CTX) -n $(NAMESPACE) get svc
+	@echo ""
+	@echo "--- pvcs ---"
+	@kubectl --context $(KUBE_CTX) -n $(NAMESPACE) get pvc

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -1,0 +1,107 @@
+# matchID on Kubernetes — local k3s + PoC overlays
+
+Experimental k8s manifests for matchID. **Not** yet wired into CI/CD; meant
+to be driven by hand on a local k3d cluster or against the `poc` Kapsule
+cluster owned by `rhanka/poc-k8s`.
+
+## Layout
+
+```
+deploy/k8s/
+├── base/                  # vendor-agnostic manifests (Deployments, Services, ES STS)
+├── overlays/
+│   ├── local/             # k3d / k3s-local: NodePort, hostPath PV, no nodeSelector
+│   └── poc/               # Scaleway Kapsule `poc`: nodeSelector pool=burst, scw-bssd PVC, IngressRoute
+└── local/                 # alias overlay used by the `apply-local` Make target
+```
+
+`base/` declares the four workloads :
+
+| Workload          | Image                                                  | Port  | Notes                                    |
+| ----------------- | ------------------------------------------------------ | ----- | ---------------------------------------- |
+| deces-backend     | `matchid/deces-backend:latest`                         | 8080  | Node.js API, talks to ES via `ES_URL`    |
+| deces-ui          | `matchid/deces-ui:latest`                              | 8083  | Nginx reverse-proxy + static UI          |
+| elasticsearch     | `docker.elastic.co/elasticsearch/elasticsearch:7.17.28`| 9200  | single-node, dev profile, JVM -Xmx512m   |
+
+> **Heads-up — ES version drift.** The repo's compose files declare
+> `ES_VERSION=8.6.1`. The poc-k8s contract demands 7.17.x to stay under
+> 1 GiB heap; we pin `7.17.28` here. Reconciling the two is part of the
+> follow-up surch swap (see `EXPERIMENT_SURCH.md`).
+
+## Local flow (recommended: k3d)
+
+`k3d` runs k3s inside Docker — fastest path on a dev box, no host changes.
+
+```bash
+# one-shot install
+brew install k3d                                          # macOS
+curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash  # linux
+
+# spin up + apply
+make -C deploy/k8s k3d-up
+make -C deploy/k8s apply-local
+make -C deploy/k8s port-forward                           # http://localhost:8083 → deces-ui
+```
+
+Alternative (host-mode k3s, requires root):
+
+```bash
+curl -sfL https://get.k3s.io | sh -                        # systemd service `k3s`
+sudo k3s kubectl apply -k deploy/k8s/overlays/local/
+```
+
+## PoC cluster flow
+
+Once the matchID tenant lands in `rhanka/poc-k8s` (see
+`requests/matchid.md` on branch `request/matchid-onboarding`) :
+
+```bash
+export KUBECONFIG=$(scw k8s kubeconfig get poc | grep KUBECONFIG | cut -d= -f2)
+kubectl apply -k deploy/k8s/overlays/poc/
+kubectl -n matchid wait --for=condition=available --timeout=5m deploy/deces-backend deploy/deces-ui
+```
+
+The `poc` overlay assumes :
+
+- a `burst` node-pool labelled `pool=burst` with toleration
+  `pool=burst:NoSchedule` (provisioned by `poc-k8s/Makefile::pool-burst`),
+- a `scw-bssd` StorageClass for ES persistence,
+- a `traefik` IngressRoute CRD on the cluster (default on Kapsule),
+- the `matchid` Namespace + ResourceQuota + LimitRange already applied
+  by the poc-k8s repo from `tenants/matchid/00-namespace.yaml`.
+
+## What's not yet wired
+
+- **TLS / cert-manager** — the `IngressRoute` references TLS via
+  `cert-manager.io/cluster-issuer: letsencrypt-prod` but the issuer
+  is provisioned out of band by the poc-k8s repo. To be amended once
+  the issuer lands.
+- **OIDC auth** — matchID OTP / SMTP flow not wired yet. The
+  Deployment env block carries placeholders pointing at the future
+  `mail.matchid.io` Brevo→Scaleway TEM relay.
+- **Surch swap** — the long-term plan is to drop the ES StatefulSet
+  and point `deces-backend` at the surch tenant's `surch-api` Service.
+  Blocked on the DSL inventory in `EXPERIMENT_SURCH.md`.
+- **CI/CD** — no `.github/workflows/k8s-*.yml` yet. The poc-k8s
+  intake assumes a future `experiment/k8s` workflow doing
+  `kubectl apply -k …/overlays/poc/`.
+- **Secrets** — backend secrets (`BACKEND_TOKEN_KEY`, SMTP creds,
+  etc.) declared as `envFrom: secretRef` but the Secret itself is
+  out-of-tree; provision via `kubectl create secret generic
+  deces-backend-secrets --from-env-file=.env.k8s`.
+- **Dataprep** — `deces-dataprep` (the INSEE ingest job) is not
+  manifested yet; it's a one-shot Job that should live alongside
+  the ES StatefulSet but we want to land the read path first.
+
+## Resource sizing
+
+Aligned 1:1 with the poc-k8s intake (`requests/matchid.md`) :
+
+| Pod            | CPU req / limit | RAM req / limit | Notes                  |
+| -------------- | --------------- | --------------- | ---------------------- |
+| deces-backend  | 100m / 500m     | 256Mi / 512Mi   | single replica         |
+| deces-ui       | 50m  / 200m     | 64Mi  / 128Mi   | single replica         |
+| elasticsearch  | 250m / 1500m    | 512Mi / 1Gi     | dev profile, 512m heap |
+
+Totals : **400m / 2200m CPU, 832Mi / 1664Mi RAM** — fits inside the
+proposed quota (500m/2500m + 512Mi/3Gi).

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -4,6 +4,18 @@ Experimental k8s manifests for matchID. **Not** yet wired into CI/CD; meant
 to be driven by hand on a local k3d cluster or against the `poc` Kapsule
 cluster owned by `rhanka/poc-k8s`.
 
+## Environment tiers (target topology)
+
+| Tier        | Cluster                                     | Overlay                  | Lifecycle                                     |
+| ----------- | ------------------------------------------- | ------------------------ | --------------------------------------------- |
+| **CI**      | k3s in GH Actions (or k3d if a local runner is free) | `overlays/local`         | Ephemeral per job — bring up, smoke, tear down |
+| **Dev**     | Scaleway Kapsule `poc` (shared, fr-par-2)   | `overlays/poc`           | Long-running tenant, namespace `matchid`      |
+| **Prod**    | Dedicated cluster (TBD — not Kapsule `poc`) | `overlays/prod` (future) | Stable, separate IaC stack                    |
+
+Local k3d runs are convenient when the laptop has headroom; CI falls back to
+k3s when local is saturated. `overlays/local` is shared between both — it just
+needs a working k3s/k3d.
+
 ## Layout
 
 ```
@@ -31,6 +43,15 @@ deploy/k8s/
 ## Local flow (recommended: k3d)
 
 `k3d` runs k3s inside Docker — fastest path on a dev box, no host changes.
+
+**Prerequisites :**
+
+- **Docker** + **kubectl** + **k3d** installed and on `PATH`.
+- ≥ **15% free space on `/`** (or wherever `/var/lib/docker` lives). Below
+  that, k3s's kubelet sets the `DiskPressure` taint on the node and no Pod
+  can be scheduled — `kubectl describe node …` will show the taint, and
+  every workload sits in `Pending`. Free disk (`docker system prune -af`,
+  prune dataprep snapshots) then `make k3d-down && make k3d-up`.
 
 ```bash
 # one-shot install

--- a/deploy/k8s/base/deces-backend.deployment.yaml
+++ b/deploy/k8s/base/deces-backend.deployment.yaml
@@ -35,6 +35,10 @@ spec:
               value: "8080"
             - name: APP
               value: deces-backend
+            - name: APP_DNS
+              value: deces.local
+            - name: APP_URL
+              value: http://deces.local
             - name: ES_URL
               value: http://elasticsearch:9200
             - name: ES_INDEX
@@ -43,6 +47,39 @@ spec:
               value: /deces/api/v1
             - name: BACKEND_LOG_LEVEL
               value: info
+            - name: BACKEND_LOG_TIMER
+              value: "60"
+            # BullMQ Worker constructor REJECTS concurrency=undefined with
+            # "concurrency must be a finite number greater than 0". Defaults
+            # mirror the docker-compose values from packages/deces-backend.
+            - name: BACKEND_JOB_CONCURRENCY
+              value: "2"
+            - name: BACKEND_CHUNK_CONCURRENCY
+              value: "2"
+            - name: BACKEND_TMPFILE_PERSISTENCE
+              value: "3000"
+            - name: BACKEND_TMP_DURATION
+              value: "3600"
+            - name: BACKEND_TMP_MAX
+              value: "5"
+            - name: BACKEND_TMP_WINDOW
+              value: "60"
+            # File paths read at import time (mail.ts, communes.ts, etc.).
+            # Pointing at /dev/null lets the requires return empty data and
+            # log a soft warning rather than crash.
+            - name: DISPOSABLE_MAIL
+              value: /dev/null
+            - name: COMMUNES_JSON
+              value: /dev/null
+            - name: DB_JSON
+              value: /dev/null
+            - name: WIKIDATA_LINKS
+              value: /dev/null
+            # BullMQ Redis broker
+            - name: REDIS_HOST
+              value: redis
+            - name: REDIS_PORT
+              value: "6379"
           envFrom:
             - secretRef:
                 name: deces-backend-secrets

--- a/deploy/k8s/base/deces-backend.deployment.yaml
+++ b/deploy/k8s/base/deces-backend.deployment.yaml
@@ -1,0 +1,70 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deces-backend
+  labels:
+    app.kubernetes.io/name: deces-backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: matchid
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: deces-backend
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: deces-backend
+        app.kubernetes.io/component: backend
+        app.kubernetes.io/part-of: matchid
+    spec:
+      containers:
+        - name: deces-backend
+          image: matchid/deces-backend:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: NODE_ENV
+              value: production
+            - name: BACKEND_PORT
+              value: "8080"
+            - name: APP
+              value: deces-backend
+            - name: ES_URL
+              value: http://elasticsearch:9200
+            - name: ES_INDEX
+              value: deces
+            - name: BACKEND_PROXY_PATH
+              value: /deces/api/v1
+            - name: BACKEND_LOG_LEVEL
+              value: info
+          envFrom:
+            - secretRef:
+                name: deces-backend-secrets
+                optional: true
+          readinessProbe:
+            httpGet:
+              path: /deces/api/v1/healthcheck
+              port: http
+            initialDelaySeconds: 15
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /deces/api/v1/healthcheck
+              port: http
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+          resources:
+            requests:
+              cpu: 100m
+              memory: 256Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi

--- a/deploy/k8s/base/deces-backend.service.yaml
+++ b/deploy/k8s/base/deces-backend.service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deces-backend
+  labels:
+    app.kubernetes.io/name: deces-backend
+    app.kubernetes.io/component: backend
+    app.kubernetes.io/part-of: matchid
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: deces-backend
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      protocol: TCP

--- a/deploy/k8s/base/deces-ui.configmap.yaml
+++ b/deploy/k8s/base/deces-ui.configmap.yaml
@@ -1,0 +1,38 @@
+# Defaults for the nginx.template placeholders that run.sh sed-substitutes
+# at container boot. Values copied verbatim from packages/deces-ui/Makefile.
+# Override per-overlay if needed (e.g. tighter limits in prod).
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: deces-ui-nginx
+  labels:
+    app.kubernetes.io/name: deces-ui
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: matchid
+data:
+  API_USER_SCOPE: "http_x_forwarded_for"
+  API_SEARCH_LIMIT_RATE: "1r/s"
+  API_SEARCH_USER_BURST: "30 nodelay"
+  API_SEARCH_GLOBAL_LIMIT_RATE: "20r/s"
+  API_SEARCH_GLOBAL_BURST: "400 nodelay"
+  API_BULK_SUBMIT_LIMIT_RATE: "4r/m"
+  API_BULK_SUBMIT_BURST: "4 nodelay"
+  API_MISC_LIMIT_RATE: "2r/s"
+  API_MISC_USER_BURST: "7 nodelay"
+  API_MISC_GLOBAL_LIMIT_RATE: "5r/s"
+  API_MISC_GLOBAL_BURST: "40 nodelay"
+  API_AGG_LIMIT_RATE: "30r/m"
+  API_AGG_USER_BURST: "15 nodelay"
+  API_AGG_GLOBAL_LIMIT_RATE: "1r/s"
+  API_AGG_GLOBAL_BURST: "30 nodelay"
+  API_DOWNLOAD_LIMIT_RATE: "1r/m"
+  API_READ_TIMEOUT: "3600"
+  API_SEND_TIMEOUT: "1200"
+  API_MAX_BODY: "100m"
+  GOOGLE_ANALYTICS_ID: ""
+  GOOGLE_ADSENSE_ID: ""
+  DATAGOUV_PROXY_PATH: "/datagouv"
+  DATAGOUV_RESOURCES_PROXY: "https://www.data.gouv.fr"
+  DATAGOUV_RESOURCES_REWRITE_PATH: "/fr/datasets/r/"
+  # The CSP is long enough that we keep it on one line — k8s tolerates this.
+  NGINX_CSP: "default-src 'self';script-src 'self' 'unsafe-inline' 'unsafe-eval' static.cloudflareinsights.com ajax.cloudflare.com www.googletagmanager.com fundingchoicesmessages.google.com www.google.com www.google.ca analytics.google.com www.google-analytics.com pagead2.googlesyndication.com partner.googleadservices.com tpc.googlesyndication.com www.googletagservices.com adservice.google.com adservice.google.fr;style-src https: 'self' 'unsafe-inline';font-src 'self' data:;img-src 'self' matchid.io a.basemaps.cartocdn.com b.basemaps.cartocdn.com c.basemaps.cartocdn.com upload.wikimedia.org pagead2.googlesyndication.com www.google-analytics.com stats.g.doubleclick.net www.google.fr;connect-src 'self' www.data.gouv.fr cloudflareinsights.com www.google-analytics.com analytics.google.com csi.gstatic.com region1.analytics.google.com stats.g.doubleclick.net pagead2.googlesyndication.com; frame-src 'self' matchid.io www.google.com google.com googleads.g.doubleclick.net tpc.googlesyndication.com"

--- a/deploy/k8s/base/deces-ui.deployment.yaml
+++ b/deploy/k8s/base/deces-ui.deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deces-ui
+  labels:
+    app.kubernetes.io/name: deces-ui
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: matchid
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: deces-ui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: deces-ui
+        app.kubernetes.io/component: frontend
+        app.kubernetes.io/part-of: matchid
+    spec:
+      containers:
+        - name: deces-ui
+          image: matchid/deces-ui:latest
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8083
+              protocol: TCP
+          env:
+            - name: APP_FRONTEND
+              value: deces-ui
+            - name: PORT
+              value: "8083"
+            - name: BACKEND_HOST
+              value: deces-backend
+            - name: BACKEND_PORT
+              value: "8080"
+            - name: BACKEND_PROXY_PATH
+              value: /deces/api/v1
+            - name: ES_HOST
+              value: elasticsearch
+            - name: ES_PORT
+              value: "9200"
+            - name: ES_INDEX
+              value: deces
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi

--- a/deploy/k8s/base/deces-ui.deployment.yaml
+++ b/deploy/k8s/base/deces-ui.deployment.yaml
@@ -53,6 +53,11 @@ spec:
               value: "9200"
             - name: ES_INDEX
               value: deces
+          envFrom:
+            # All <NGINX_TEMPLATE_PLACEHOLDER> defaults: API_*, NGINX_CSP,
+            # GOOGLE_*, DATAGOUV_*. See deces-ui.configmap.yaml.
+            - configMapRef:
+                name: deces-ui-nginx
           readinessProbe:
             httpGet:
               path: /

--- a/deploy/k8s/base/deces-ui.deployment.yaml
+++ b/deploy/k8s/base/deces-ui.deployment.yaml
@@ -32,6 +32,11 @@ spec:
               containerPort: 8083
               protocol: TCP
           env:
+            # The image's nginx/run.sh (built 2026-04-26) checks `APP`, not
+            # `APP_FRONTEND`. Keep both so this manifest also works against a
+            # rebuilt image once main lands the rename.
+            - name: APP
+              value: deces-ui
             - name: APP_FRONTEND
               value: deces-ui
             - name: PORT

--- a/deploy/k8s/base/deces-ui.service.yaml
+++ b/deploy/k8s/base/deces-ui.service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: deces-ui
+  labels:
+    app.kubernetes.io/name: deces-ui
+    app.kubernetes.io/component: frontend
+    app.kubernetes.io/part-of: matchid
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: deces-ui
+  ports:
+    - name: http
+      port: 8083
+      targetPort: http
+      protocol: TCP

--- a/deploy/k8s/base/elasticsearch.statefulset.yaml
+++ b/deploy/k8s/base/elasticsearch.statefulset.yaml
@@ -1,0 +1,105 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: elasticsearch
+  labels:
+    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/component: search
+    app.kubernetes.io/part-of: matchid
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: elasticsearch
+  ports:
+    - name: http
+      port: 9200
+      targetPort: http
+      protocol: TCP
+    - name: transport
+      port: 9300
+      targetPort: transport
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+  labels:
+    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/component: search
+    app.kubernetes.io/part-of: matchid
+spec:
+  serviceName: elasticsearch
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: elasticsearch
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: elasticsearch
+        app.kubernetes.io/component: search
+        app.kubernetes.io/part-of: matchid
+    spec:
+      securityContext:
+        fsGroup: 1000
+      initContainers:
+        - name: sysctl-vm-max-map-count
+          image: busybox:1.36
+          command: ["sh", "-c", "sysctl -w vm.max_map_count=262144 || true"]
+          securityContext:
+            privileged: true
+      containers:
+        - name: elasticsearch
+          image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9200
+              protocol: TCP
+            - name: transport
+              containerPort: 9300
+              protocol: TCP
+          env:
+            - name: cluster.name
+              value: matchid-cluster
+            - name: discovery.type
+              value: single-node
+            - name: xpack.security.enabled
+              value: "false"
+            - name: bootstrap.memory_lock
+              value: "false"
+            - name: ES_JAVA_OPTS
+              value: "-Xms512m -Xmx512m"
+            - name: LOG4J_FORMAT_MSG_NO_LOOKUPS
+              value: "true"
+          readinessProbe:
+            httpGet:
+              path: /_cluster/health?local=true
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 12
+          livenessProbe:
+            tcpSocket:
+              port: transport
+            initialDelaySeconds: 90
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 250m
+              memory: 512Mi
+            limits:
+              cpu: 1500m
+              memory: 1Gi
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        resources:
+          requests:
+            storage: 5Gi

--- a/deploy/k8s/base/elasticsearch.statefulset.yaml
+++ b/deploy/k8s/base/elasticsearch.statefulset.yaml
@@ -49,6 +49,20 @@ spec:
           command: ["sh", "-c", "sysctl -w vm.max_map_count=262144 || true"]
           securityContext:
             privileged: true
+        - name: fix-data-permissions
+          # ES image runs as uid 1000; some storage drivers (hostPath, plain
+          # local PV) don't honour fsGroup, leaving the mount root-owned and
+          # crashing ES with AccessDeniedException on data/nodes at boot.
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - chown -R 1000:1000 /usr/share/elasticsearch/data
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+          securityContext:
+            runAsUser: 0
       containers:
         - name: elasticsearch
           image: docker.elastic.co/elasticsearch/elasticsearch:7.17.28

--- a/deploy/k8s/base/ingress.yaml
+++ b/deploy/k8s/base/ingress.yaml
@@ -1,0 +1,24 @@
+# Traefik IngressRoute CRD — present by default on k3s/k3d AND on Kapsule.
+# For non-Traefik clusters, swap this for a standard `networking.k8s.io/v1`
+# Ingress (left as a follow-up).
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: deces
+  labels:
+    app.kubernetes.io/name: matchid
+    app.kubernetes.io/part-of: matchid
+spec:
+  entryPoints:
+    - web
+  routes:
+    - match: Host(`deces.local`) && PathPrefix(`/deces/api/v1`)
+      kind: Rule
+      services:
+        - name: deces-backend
+          port: 8080
+    - match: Host(`deces.local`)
+      kind: Rule
+      services:
+        - name: deces-ui
+          port: 8083

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -11,6 +11,7 @@ labels:
 resources:
   - namespace.yaml
   - elasticsearch.statefulset.yaml
+  - redis.deployment.yaml
   - deces-backend.deployment.yaml
   - deces-backend.service.yaml
   - deces-ui.deployment.yaml

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -14,6 +14,7 @@ resources:
   - redis.deployment.yaml
   - deces-backend.deployment.yaml
   - deces-backend.service.yaml
+  - deces-ui.configmap.yaml
   - deces-ui.deployment.yaml
   - deces-ui.service.yaml
   - ingress.yaml

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -1,0 +1,18 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: matchid
+
+labels:
+  - pairs:
+      app.kubernetes.io/part-of: matchid
+    includeSelectors: true
+
+resources:
+  - namespace.yaml
+  - elasticsearch.statefulset.yaml
+  - deces-backend.deployment.yaml
+  - deces-backend.service.yaml
+  - deces-ui.deployment.yaml
+  - deces-ui.service.yaml
+  - ingress.yaml

--- a/deploy/k8s/base/namespace.yaml
+++ b/deploy/k8s/base/namespace.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: matchid
+  labels:
+    app.kubernetes.io/name: matchid
+    sentropic.dev/tenant: matchid

--- a/deploy/k8s/base/redis.deployment.yaml
+++ b/deploy/k8s/base/redis.deployment.yaml
@@ -1,0 +1,70 @@
+# Redis — backing store for BullMQ workers in deces-backend.
+# Single-replica, ephemeral (data lives in-memory, no PVC). Good enough for
+# the smoke gate and dev usage; production should use a managed Redis or a
+# StatefulSet with persistence.
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: queue
+    app.kubernetes.io/part-of: matchid
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: redis
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: redis
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: queue
+    app.kubernetes.io/part-of: matchid
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/component: queue
+        app.kubernetes.io/part-of: matchid
+    spec:
+      containers:
+        - name: redis
+          image: redis:7.2-alpine
+          imagePullPolicy: IfNotPresent
+          args: ["--maxmemory", "128mb", "--maxmemory-policy", "allkeys-lru"]
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          readinessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 2
+            periodSeconds: 5
+          livenessProbe:
+            tcpSocket:
+              port: redis
+            initialDelaySeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 25m
+              memory: 32Mi
+            limits:
+              cpu: 100m
+              memory: 192Mi

--- a/deploy/k8s/local/kustomization.yaml
+++ b/deploy/k8s/local/kustomization.yaml
@@ -1,0 +1,9 @@
+# Alias overlay — convenient `kubectl apply -k deploy/k8s/local/` entry point
+# that re-exports `overlays/local/`. Keeping the real patches in
+# `overlays/local/` matches the standard kustomize convention while letting
+# top-level scripts use a short path.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ../overlays/local

--- a/deploy/k8s/overlays/local/deces-backend.nodeport.yaml
+++ b/deploy/k8s/overlays/local/deces-backend.nodeport.yaml
@@ -1,0 +1,14 @@
+# Local overlay : expose deces-backend through a NodePort to make
+# direct API hits easy during development (Swagger, curl, postman).
+apiVersion: v1
+kind: Service
+metadata:
+  name: deces-backend
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http
+      nodePort: 30080
+      protocol: TCP

--- a/deploy/k8s/overlays/local/deces-ui.nodeport.yaml
+++ b/deploy/k8s/overlays/local/deces-ui.nodeport.yaml
@@ -1,0 +1,14 @@
+# Local overlay : expose deces-ui through a NodePort so `k3d` users can
+# reach it on http://localhost:30083 without an Ingress controller.
+apiVersion: v1
+kind: Service
+metadata:
+  name: deces-ui
+spec:
+  type: NodePort
+  ports:
+    - name: http
+      port: 8083
+      targetPort: http
+      nodePort: 30083
+      protocol: TCP

--- a/deploy/k8s/overlays/local/elasticsearch.local-storage.yaml
+++ b/deploy/k8s/overlays/local/elasticsearch.local-storage.yaml
@@ -1,0 +1,20 @@
+# Local overlay : bind the STS volumeClaimTemplate to the hostPath PV above
+# and drop the privileged sysctl init container — k3d / k3s already ships
+# with vm.max_map_count high enough for a single-node dev ES.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+spec:
+  template:
+    spec:
+      initContainers: []
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: matchid-local
+        resources:
+          requests:
+            storage: 5Gi

--- a/deploy/k8s/overlays/local/elasticsearch.local-storage.yaml
+++ b/deploy/k8s/overlays/local/elasticsearch.local-storage.yaml
@@ -1,6 +1,8 @@
-# Local overlay : bind the STS volumeClaimTemplate to the hostPath PV above
-# and drop the privileged sysctl init container — k3d / k3s already ships
-# with vm.max_map_count high enough for a single-node dev ES.
+# Local overlay : bind the STS volumeClaimTemplate to the hostPath PV above.
+# Keep ONLY the fix-data-permissions init container — k3d / k3s already
+# ship with vm.max_map_count high enough so the sysctl init is dropped,
+# but hostPath does NOT honour fsGroup (mount lands root-owned and ES
+# crashes with AccessDeniedException on data/nodes).
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -8,7 +10,18 @@ metadata:
 spec:
   template:
     spec:
-      initContainers: []
+      initContainers:
+        - name: fix-data-permissions
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - chown -R 1000:1000 /usr/share/elasticsearch/data
+          volumeMounts:
+            - name: data
+              mountPath: /usr/share/elasticsearch/data
+          securityContext:
+            runAsUser: 0
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/deploy/k8s/overlays/local/es-data-pv.yaml
+++ b/deploy/k8s/overlays/local/es-data-pv.yaml
@@ -1,0 +1,21 @@
+# Local overlay : pre-create a hostPath PV so the ES StatefulSet's
+# volumeClaimTemplate binds without needing a dynamic provisioner.
+# `local-path` (k3s default StorageClass) would also work — kept this
+# explicit PV variant for plain `kubectl` users without local-path.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: elasticsearch-data-local
+  labels:
+    app.kubernetes.io/name: elasticsearch
+    app.kubernetes.io/part-of: matchid
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: matchid-local
+  hostPath:
+    path: /tmp/matchid-elasticsearch-data
+    type: DirectoryOrCreate

--- a/deploy/k8s/overlays/local/kustomization.yaml
+++ b/deploy/k8s/overlays/local/kustomization.yaml
@@ -1,0 +1,22 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: matchid
+
+resources:
+  - ../../base
+  - es-data-pv.yaml
+
+patches:
+  - path: deces-ui.nodeport.yaml
+    target:
+      kind: Service
+      name: deces-ui
+  - path: deces-backend.nodeport.yaml
+    target:
+      kind: Service
+      name: deces-backend
+  - path: elasticsearch.local-storage.yaml
+    target:
+      kind: StatefulSet
+      name: elasticsearch

--- a/deploy/k8s/overlays/poc/deces-backend.poc.yaml
+++ b/deploy/k8s/overlays/poc/deces-backend.poc.yaml
@@ -1,0 +1,18 @@
+# PoC overlay : keep deces-backend at 0 replicas at rest (burst-mode
+# tenant — see `requests/matchid.md` on rhanka/poc-k8s). A GitHub
+# Actions test session bumps this to 1 and back to 0 on tear-down.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deces-backend
+spec:
+  replicas: 0
+  template:
+    spec:
+      nodeSelector:
+        pool: burst
+      tolerations:
+        - key: pool
+          operator: Equal
+          value: burst
+          effect: NoSchedule

--- a/deploy/k8s/overlays/poc/deces-ui.poc.yaml
+++ b/deploy/k8s/overlays/poc/deces-ui.poc.yaml
@@ -1,0 +1,16 @@
+# PoC overlay : same burst-mode treatment as deces-backend.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: deces-ui
+spec:
+  replicas: 0
+  template:
+    spec:
+      nodeSelector:
+        pool: burst
+      tolerations:
+        - key: pool
+          operator: Equal
+          value: burst
+          effect: NoSchedule

--- a/deploy/k8s/overlays/poc/elasticsearch.poc.yaml
+++ b/deploy/k8s/overlays/poc/elasticsearch.poc.yaml
@@ -1,0 +1,29 @@
+# PoC overlay : pin ES to the `burst` pool (DEV1-L, 0..3 autoscaled).
+# Burst pool taint `pool=burst:NoSchedule` is provisioned by
+# `poc-k8s/Makefile::pool-burst`.
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: elasticsearch
+spec:
+  # Burst-mode: at rest the namespace consumes 0 CPU / 0 RAM. A test
+  # session scales ES → 1 before the backend Deployment ramps up.
+  replicas: 0
+  template:
+    spec:
+      nodeSelector:
+        pool: burst
+      tolerations:
+        - key: pool
+          operator: Equal
+          value: burst
+          effect: NoSchedule
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: scw-bssd
+        resources:
+          requests:
+            storage: 5Gi

--- a/deploy/k8s/overlays/poc/ingress.poc.yaml
+++ b/deploy/k8s/overlays/poc/ingress.poc.yaml
@@ -1,0 +1,24 @@
+# PoC overlay : real hostname behind cert-manager-issued TLS.
+# The `letsencrypt-prod` ClusterIssuer is provisioned by the poc-k8s repo.
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: deces
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - match: Host(`matchid-poc.matchid.io`) && PathPrefix(`/deces/api/v1`)
+      kind: Rule
+      services:
+        - name: deces-backend
+          port: 8080
+    - match: Host(`matchid-poc.matchid.io`)
+      kind: Rule
+      services:
+        - name: deces-ui
+          port: 8083
+  tls:
+    secretName: matchid-poc-tls

--- a/deploy/k8s/overlays/poc/kustomization.yaml
+++ b/deploy/k8s/overlays/poc/kustomization.yaml
@@ -1,0 +1,38 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: matchid
+
+resources:
+  - ../../base
+
+# The poc-k8s repo owns the Namespace + ResourceQuota + LimitRange +
+# default-deny NetworkPolicy (see `tenants/matchid/00-namespace.yaml` on
+# `rhanka/poc-k8s` branch `request/matchid-onboarding`). We skip the
+# base/namespace.yaml here to avoid stomping on it.
+patches:
+  - patch: |-
+      $patch: delete
+      apiVersion: v1
+      kind: Namespace
+      metadata:
+        name: matchid
+    target:
+      kind: Namespace
+      name: matchid
+  - path: elasticsearch.poc.yaml
+    target:
+      kind: StatefulSet
+      name: elasticsearch
+  - path: deces-backend.poc.yaml
+    target:
+      kind: Deployment
+      name: deces-backend
+  - path: deces-ui.poc.yaml
+    target:
+      kind: Deployment
+      name: deces-ui
+  - path: ingress.poc.yaml
+    target:
+      kind: IngressRoute
+      name: deces


### PR DESCRIPTION
## Summary

Scaffold of `deploy/k8s/` with a kustomize **base** + overlays for:

- `overlays/local` — k3d / k3s local: NodePort, hostPath PV, no nodeSelector.
- `overlays/poc` — Scaleway Kapsule `poc`: `pool=burst` nodeSelector, `scw-bssd` PVCs, Traefik IngressRoute.
- `overlays/prod` — placeholder only; production remains out of scope for this POC branch.

This PR lands the **POC scaffolding**. It is not a production migration and it does not replace the current `deploy-remote` path.

## Scope

Workloads in `base/`:

| Pod            | Image                                                   | Port |
| -------------- | ------------------------------------------------------- | ---- |
| deces-backend  | `matchid/deces-backend:latest`                          | 8080 |
| deces-ui       | `matchid/deces-ui:latest`                               | 8083 |
| elasticsearch  | `docker.elastic.co/elasticsearch/elasticsearch:7.17.28` | 9200 |
| redis          | `redis:7-alpine`                                        | 6379 |

ES is pinned to 7.17.28 for the POC quota. The long-term ES-to-surch swap remains a separate experiment.

## External Contract

- `rhanka/poc-k8s#3` intake for matchID is merged.
- The live Kapsule smoke must follow the `poc-k8s` tenant mechanism: tenant namespace + tenant kubeconfig / `KUBE_CONFIG_DATA`, or the later OIDC contract if/when it lands there.
- This PR does not invent a separate production-style SCW credential path for matchID.

## Validation

- Local k8s smoke CI is green:
  - push run `25975527555`: `smoke-local (k3s in runner)` success
  - PR run `25975528412`: `smoke-local (k3s in runner)` success
- PR code review result: merge-with-followup, no blocker.

## Follow-Ups

- Track B: wire the POC Kapsule smoke according to `../poc-k8s` contract, then run it.
- Track k8s-hardening: do not promote to prod while images are `:latest` / `IfNotPresent`, ES is single-node, and app state issues from `deploy/k8s/K8S_READINESS_AUDIT.md` remain open.

Generated with [Claude Code](https://claude.com/claude-code)
