### PR TITLE
fix(k8s): make poc ingress optional

### DIFF
--- a/.github/workflows/k8s-smoke.yml
+++ b/.github/workflows/k8s-smoke.yml
@@ -162,6 +162,15 @@ jobs:
           kubectl apply -k deploy/k8s/overlays/poc/
           kubectl -n matchid get all
 
+      - name: Apply optional IngressRoute
+        run: |
+          set -euo pipefail
+          if kubectl api-resources --api-group=traefik.io | awk '$1 == "ingressroutes" { found = 1 } END { exit !found }'; then
+            kubectl -n matchid apply -f deploy/k8s/overlays/poc/ingress.poc.yaml
+          else
+            echo "::warning::Traefik IngressRoute CRD is not installed; smoke will use port-forward fallback"
+          fi
+
       - name: Start poc session
         run: |
           set +e
@@ -181,13 +190,16 @@ jobs:
             exit 1
           fi
 
-      - name: Smoke via IngressRoute
+      - name: Smoke via ingress or port-forward
         run: |
-          # The poc overlay publishes an IngressRoute. We don't TLS-validate here.
-          # Find the ingress public endpoint via the LoadBalancer service Traefik exposes.
-          TRAEFIK_LB=$(kubectl -n kube-system get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+          # Prefer the platform ingress if present; otherwise keep the POC smoke
+          # tenant-scoped by port-forwarding the backend service.
+          TRAEFIK_LB=$(kubectl -n traefik get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
           if [ -z "$TRAEFIK_LB" ]; then
-            echo "::warning::No Traefik LB IP yet — falling back to port-forward smoke"
+            TRAEFIK_LB=$(kubectl -n kube-system get svc traefik -o jsonpath='{.status.loadBalancer.ingress[0].ip}' 2>/dev/null || true)
+          fi
+          if [ -z "$TRAEFIK_LB" ]; then
+            echo "::warning::No Traefik LB IP; falling back to port-forward smoke"
             kubectl -n matchid port-forward svc/deces-backend 8080:8080 &
             PF=$!
             sleep 4

--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -86,7 +86,8 @@ The `poc` overlay assumes :
 - a `burst` node-pool labelled `pool=burst` with toleration
   `pool=burst:NoSchedule` (provisioned by `poc-k8s/Makefile::pool-burst`),
 - a `scw-bssd` StorageClass for ES persistence,
-- a `traefik` IngressRoute CRD on the cluster (default on Kapsule),
+- optionally, a `traefik` IngressRoute CRD on the cluster. If it is not
+  installed, the manual POC smoke uses a backend `kubectl port-forward`,
 - the `matchid` Namespace + ResourceQuota + LimitRange already applied by
   `poc-k8s` from `tenants/matchid/00-namespace.yaml`,
 - a tenant-scoped kubeconfig stored in the matchID repo secret
@@ -105,9 +106,9 @@ The `poc` overlay assumes :
 - **Surch swap** — the long-term plan is to drop the ES StatefulSet
   and point `deces-backend` at the surch tenant's `surch-api` Service.
   Blocked on the DSL inventory in `EXPERIMENT_SURCH.md`.
-- **CI/CD** — no `.github/workflows/k8s-*.yml` yet. The poc-k8s
-  intake assumes a future `experiment/k8s` workflow doing
-  `kubectl apply -k …/overlays/poc/`.
+- **Ingress** — the POC smoke can run without Traefik through
+  `kubectl port-forward`. Public ingress remains pending until `poc-k8s`
+  provisions Traefik and cert-manager.
 - **Secrets** — backend secrets (`BACKEND_TOKEN_KEY`, SMTP creds,
   etc.) declared as `envFrom: secretRef` but the Secret itself is
   out-of-tree; provision via `kubectl create secret generic

--- a/deploy/k8s/overlays/poc/kustomization.yaml
+++ b/deploy/k8s/overlays/poc/kustomization.yaml
@@ -20,6 +20,17 @@ patches:
     target:
       kind: Namespace
       name: matchid
+  - patch: |-
+      $patch: delete
+      apiVersion: traefik.io/v1alpha1
+      kind: IngressRoute
+      metadata:
+        name: deces
+    target:
+      group: traefik.io
+      version: v1alpha1
+      kind: IngressRoute
+      name: deces
   - path: elasticsearch.poc.yaml
     target:
       kind: StatefulSet
@@ -36,7 +47,3 @@ patches:
     target:
       kind: Deployment
       name: redis
-  - path: ingress.poc.yaml
-    target:
-      kind: IngressRoute
-      name: deces


### PR DESCRIPTION
## Summary

Makes the POC IngressRoute optional so the manual smoke can run on the current `poc-k8s` cluster, which has the `matchid` tenant but no Traefik CRD/controller installed yet.

Changes:

- removes the base `IngressRoute` from the mandatory POC overlay render
- applies `ingress.poc.yaml` separately only when the `traefik.io` `IngressRoute` API is available
- keeps the existing port-forward fallback for clusters without a Traefik LoadBalancer
- updates the k8s README to document ingress as optional for the smoke path

## Validation

- workflow YAML parsed with PyYAML
- `git diff --check`
- `kubectl kustomize deploy/k8s/overlays/poc` confirms the mandatory render has no `IngressRoute` and keeps all workloads at `replicas: 0`

## Context

Run `26006787805` proved that `KUBE_CONFIG_DATA` works and the `matchid` namespace is reachable. It failed only because the cluster lacks `traefik.io/v1alpha1/IngressRoute`.
