### PR TITLE
fix(k8s): target scaleway burst pool label

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -83,8 +83,8 @@ gh workflow run k8s-smoke.yml -R matchID-project/matchID --ref dev -f target=poc
 
 The `poc` overlay assumes :
 
-- a `burst` node-pool labelled `pool=burst` with toleration
-  `pool=burst:NoSchedule` (provisioned by `poc-k8s/Makefile::pool-burst`),
+- a Scaleway `burst` node-pool; the POC overlay targets it with the
+  managed label `k8s.scaleway.com/pool-name=burst`,
 - a `scw-bssd` StorageClass for ES persistence,
 - optionally, a `traefik` IngressRoute CRD on the cluster. If it is not
   installed, the manual POC smoke uses a backend `kubectl port-forward`,

--- a/deploy/k8s/overlays/poc/deces-backend.poc.yaml
+++ b/deploy/k8s/overlays/poc/deces-backend.poc.yaml
@@ -10,9 +10,4 @@ spec:
   template:
     spec:
       nodeSelector:
-        pool: burst
-      tolerations:
-        - key: pool
-          operator: Equal
-          value: burst
-          effect: NoSchedule
+        k8s.scaleway.com/pool-name: burst

--- a/deploy/k8s/overlays/poc/deces-ui.poc.yaml
+++ b/deploy/k8s/overlays/poc/deces-ui.poc.yaml
@@ -8,9 +8,4 @@ spec:
   template:
     spec:
       nodeSelector:
-        pool: burst
-      tolerations:
-        - key: pool
-          operator: Equal
-          value: burst
-          effect: NoSchedule
+        k8s.scaleway.com/pool-name: burst

--- a/deploy/k8s/overlays/poc/elasticsearch.poc.yaml
+++ b/deploy/k8s/overlays/poc/elasticsearch.poc.yaml
@@ -1,6 +1,5 @@
-# PoC overlay : pin ES to the `burst` pool (DEV1-L, 0..3 autoscaled).
-# Burst pool taint `pool=burst:NoSchedule` is provisioned by
-# `poc-k8s/Makefile::pool-burst`.
+# PoC overlay : pin ES to the Scaleway-managed `burst` pool
+# (DEV1-L, 0..3 autoscaled).
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
@@ -12,12 +11,7 @@ spec:
   template:
     spec:
       nodeSelector:
-        pool: burst
-      tolerations:
-        - key: pool
-          operator: Equal
-          value: burst
-          effect: NoSchedule
+        k8s.scaleway.com/pool-name: burst
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/deploy/k8s/overlays/poc/redis.poc.yaml
+++ b/deploy/k8s/overlays/poc/redis.poc.yaml
@@ -10,9 +10,4 @@ spec:
   template:
     spec:
       nodeSelector:
-        pool: burst
-      tolerations:
-        - key: pool
-          operator: Equal
-          value: burst
-          effect: NoSchedule
+        k8s.scaleway.com/pool-name: burst


### PR DESCRIPTION
## Summary

Targets the Scaleway-managed burst pool label exposed by Kapsule.

Changes:

- replaces the unsupported `pool=burst` node selector with `k8s.scaleway.com/pool-name=burst`
- removes the `pool=burst:NoSchedule` toleration because the current Kapsule burst pool is not tainted
- updates the k8s README to document the Scaleway-managed selector

## Validation

- `git diff --check`
- `kubectl kustomize deploy/k8s/overlays/poc` confirms all POC workloads render with `k8s.scaleway.com/pool-name=burst`, stay at `replicas: 0`, and no longer include the unsupported toleration

## Context

The live POC run `26006923493` proved that the previous `pool=burst` selector does not trigger scale-up on this Kapsule cluster. Existing nodes expose pool identity as `k8s.scaleway.com/pool-name`.
