### PR TITLE
feat(k8s): add backend RWX runtime storage

### DIFF
--- a/deploy/k8s/README.md
+++ b/deploy/k8s/README.md
@@ -23,7 +23,7 @@ deploy/k8s/
 ├── base/                  # vendor-agnostic manifests (Deployments, Services, ES STS)
 ├── overlays/
 │   ├── local/             # k3d / k3s-local: NodePort, hostPath PV, no nodeSelector
-│   └── poc/               # Scaleway Kapsule `poc`: nodeSelector pool=burst, scw-bssd PVC, IngressRoute
+│   └── poc/               # Scaleway Kapsule `poc`: pool=burst, scw-bssd ES PVC, RWX runtime PVC, IngressRoute
 └── local/                 # alias overlay used by the `apply-local` Make target
 ```
 
@@ -31,7 +31,7 @@ deploy/k8s/
 
 | Workload          | Image                                                  | Port  | Notes                                    |
 | ----------------- | ------------------------------------------------------ | ----- | ---------------------------------------- |
-| deces-backend     | `matchid/deces-backend:latest`                         | 8080  | Node.js API, talks to ES via `ES_URL`    |
+| deces-backend     | `matchid/deces-backend:latest`                         | 8080  | Node.js API, talks to ES via `ES_URL`, mounts runtime files at `/var/lib/matchid` |
 | deces-ui          | `matchid/deces-ui:latest`                              | 8083  | Nginx reverse-proxy + static UI          |
 | elasticsearch     | `docker.elastic.co/elasticsearch/elasticsearch:7.17.28`| 9200  | single-node, dev profile, JVM -Xmx512m   |
 
@@ -86,6 +86,10 @@ The `poc` overlay assumes :
 - a Scaleway `burst` node-pool; the POC overlay targets it with the
   managed label `k8s.scaleway.com/pool-name=burst`,
 - a `scw-bssd` StorageClass for ES persistence,
+- a `matchid-rwx` StorageClass for `deces-backend-runtime`, backed by
+  Scaleway File Storage RWX. As of 2026-05-22 the PoC cluster only exposes
+  block StorageClasses (`scw-bssd` / `sbs-*`), so the platform repo must add
+  this StorageClass before scaling `deces-backend` above 0,
 - optionally, a `traefik` IngressRoute CRD on the cluster. If it is not
   installed, the manual POC smoke uses a backend `kubectl port-forward`,
 - the `matchid` Namespace + ResourceQuota + LimitRange already applied by

--- a/deploy/k8s/base/deces-backend-runtime.pvc.yaml
+++ b/deploy/k8s/base/deces-backend-runtime.pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: deces-backend-runtime
+  labels:
+    app.kubernetes.io/name: deces-backend
+    app.kubernetes.io/component: backend-runtime
+    app.kubernetes.io/part-of: matchid
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 5Gi

--- a/deploy/k8s/base/deces-backend.deployment.yaml
+++ b/deploy/k8s/base/deces-backend.deployment.yaml
@@ -20,6 +20,19 @@ spec:
         app.kubernetes.io/component: backend
         app.kubernetes.io/part-of: matchid
     spec:
+      initContainers:
+        - name: prepare-runtime-storage
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - >-
+              mkdir -p /var/lib/matchid/jobs /var/lib/matchid/proofs
+              && test -w /var/lib/matchid/jobs
+              && test -w /var/lib/matchid/proofs
+          volumeMounts:
+            - name: backend-runtime
+              mountPath: /var/lib/matchid
       containers:
         - name: deces-backend
           image: matchid/deces-backend:latest
@@ -64,6 +77,10 @@ spec:
               value: "5"
             - name: BACKEND_TMP_WINDOW
               value: "60"
+            - name: JOBS
+              value: /var/lib/matchid/jobs
+            - name: PROOFS
+              value: /var/lib/matchid/proofs
             # File paths read at import time (mail.ts, communes.ts, etc.).
             # Pointing at /dev/null lets the requires return empty data and
             # log a soft warning rather than crash.
@@ -84,10 +101,20 @@ spec:
             - secretRef:
                 name: deces-backend-secrets
                 optional: true
+          volumeMounts:
+            - name: backend-runtime
+              mountPath: /var/lib/matchid
           readinessProbe:
-            httpGet:
-              path: /deces/api/v1/healthcheck
-              port: http
+            exec:
+              command:
+                - sh
+                - -c
+                - >-
+                  test -w "$JOBS"
+                  && test -w "$PROOFS"
+                  && curl -fsS
+                  http://127.0.0.1:8080/deces/api/v1/healthcheck
+                  >/dev/null
             initialDelaySeconds: 15
             periodSeconds: 10
             failureThreshold: 6
@@ -105,3 +132,7 @@ spec:
             limits:
               cpu: 500m
               memory: 512Mi
+      volumes:
+        - name: backend-runtime
+          persistentVolumeClaim:
+            claimName: deces-backend-runtime

--- a/deploy/k8s/base/kustomization.yaml
+++ b/deploy/k8s/base/kustomization.yaml
@@ -10,6 +10,7 @@ labels:
 
 resources:
   - namespace.yaml
+  - deces-backend-runtime.pvc.yaml
   - elasticsearch.statefulset.yaml
   - redis.deployment.yaml
   - deces-backend.deployment.yaml

--- a/deploy/k8s/overlays/local/backend-runtime-pv.yaml
+++ b/deploy/k8s/overlays/local/backend-runtime-pv.yaml
@@ -1,0 +1,21 @@
+# Local overlay: hostPath PV for backend runtime files. hostPath is acceptable
+# for k3d/k3s smoke because all pods run on one local node; PoC/dev use RWX
+# File Storage instead.
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: deces-backend-runtime-local
+  labels:
+    app.kubernetes.io/name: deces-backend
+    app.kubernetes.io/component: backend-runtime
+    app.kubernetes.io/part-of: matchid
+spec:
+  capacity:
+    storage: 5Gi
+  accessModes:
+    - ReadWriteMany
+  persistentVolumeReclaimPolicy: Retain
+  storageClassName: matchid-local-rwx
+  hostPath:
+    path: /tmp/matchid-deces-backend-runtime
+    type: DirectoryOrCreate

--- a/deploy/k8s/overlays/local/deces-backend-runtime.local-storage.yaml
+++ b/deploy/k8s/overlays/local/deces-backend-runtime.local-storage.yaml
@@ -1,0 +1,12 @@
+# Local overlay: bind the backend runtime PVC to the hostPath RWX PV above.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: deces-backend-runtime
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: matchid-local-rwx
+  resources:
+    requests:
+      storage: 5Gi

--- a/deploy/k8s/overlays/local/kustomization.yaml
+++ b/deploy/k8s/overlays/local/kustomization.yaml
@@ -5,9 +5,14 @@ namespace: matchid
 
 resources:
   - ../../base
+  - backend-runtime-pv.yaml
   - es-data-pv.yaml
 
 patches:
+  - path: deces-backend-runtime.local-storage.yaml
+    target:
+      kind: PersistentVolumeClaim
+      name: deces-backend-runtime
   - path: deces-ui.nodeport.yaml
     target:
       kind: Service

--- a/deploy/k8s/overlays/poc/deces-backend-runtime.poc.yaml
+++ b/deploy/k8s/overlays/poc/deces-backend-runtime.poc.yaml
@@ -1,0 +1,14 @@
+# PoC overlay: `matchid-rwx` must be provided by the platform and backed by
+# Scaleway File Storage RWX. The current PoC cluster only exposes block
+# StorageClasses, so this PVC stays Pending until that contract is added.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: deces-backend-runtime
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: matchid-rwx
+  resources:
+    requests:
+      storage: 5Gi

--- a/deploy/k8s/overlays/poc/kustomization.yaml
+++ b/deploy/k8s/overlays/poc/kustomization.yaml
@@ -35,6 +35,10 @@ patches:
     target:
       kind: StatefulSet
       name: elasticsearch
+  - path: deces-backend-runtime.poc.yaml
+    target:
+      kind: PersistentVolumeClaim
+      name: deces-backend-runtime
   - path: deces-backend.poc.yaml
     target:
       kind: Deployment

--- a/docs/superpowers/plans/2026-05-22-k8s-rwx-storage.md
+++ b/docs/superpowers/plans/2026-05-22-k8s-rwx-storage.md
@@ -1,0 +1,41 @@
+# K8s RWX Storage Implementation Plan
+
+Date: 2026-05-22
+
+## Goal
+
+Wire the first Kubernetes runtime filesystem for `deces-backend` so bulk job
+files and proof uploads are no longer pod-local when running on Kubernetes.
+
+## Context
+
+- Design decision is documented in
+  `docs/superpowers/specs/2026-05-22-k8s-rwx-storage-design.md`.
+- `JOBS` and `PROOFS` are filesystem paths used by the backend at runtime.
+- Redis remains the state and coordination store.
+- Elasticsearch data stays on `ReadWriteOnce` block storage.
+- The current PoC cluster exposes only `scw-bssd` / `sbs-*` block
+  StorageClasses; File Storage RWX is not installed yet.
+
+## Steps
+
+1. Add a backend runtime `PersistentVolumeClaim` in the k8s base with
+   `ReadWriteMany`.
+2. Mount that claim in `deces-backend` at `/var/lib/matchid`.
+3. Set `JOBS=/var/lib/matchid/jobs` and
+   `PROOFS=/var/lib/matchid/proofs`.
+4. Add an init container and readiness guard so the backend does not accept
+   traffic unless both runtime paths are writable.
+5. Add a local hostPath `ReadWriteMany` PV and PVC patch for k3d/k3s smoke.
+6. Add a PoC PVC patch that requires the platform-provided `matchid-rwx`
+   StorageClass, backed by Scaleway File Storage.
+7. Update k8s docs with the new storage contract and current PoC blocker.
+8. Validate manifest rendering for local and PoC overlays.
+
+## Validation
+
+- `kubectl kustomize deploy/k8s/overlays/local`
+- `kubectl kustomize deploy/k8s/overlays/poc`
+- Check rendered `deces-backend` has the PVC mount, env vars, init container,
+  and readiness guard.
+- Check rendered PoC PVC requests `ReadWriteMany` and `matchid-rwx`.

--- a/docs/superpowers/specs/2026-05-22-k8s-rwx-storage-design.md
+++ b/docs/superpowers/specs/2026-05-22-k8s-rwx-storage-design.md
@@ -1,0 +1,171 @@
+# K8s RWX Storage Design
+
+Date: 2026-05-22
+
+## Decision
+
+Use Scaleway File Storage RWX as the first Kubernetes persistence target for
+runtime files that are currently local to `deces-backend`, while keeping state
+and durable archives in the stores that fit those responsibilities:
+
+- `JOBS`: RWX-mounted filesystem for bulk upload inputs and encrypted outputs.
+- `PROOFS`: RWX-mounted filesystem for correction JSON files and PDFs.
+- Redis: shared state, coordination, rate limits, OTP, job stop flags, and job
+  metadata.
+- S3/Object Storage: backups, retention, exports, logs, and Elasticsearch /
+  dataprep snapshots.
+- Elasticsearch data: keep on block storage or replace through the Surch track;
+  do not put ES data on RWX File Storage.
+
+This is the selected Option B: pragmatic convergence first, without pretending
+RWX is a database or a snapshot repository.
+
+## Problem
+
+The Kubernetes readiness audit identifies two file-backed runtime surfaces that
+break under pod restart or multi-replica routing:
+
+- `$JOBS`: bulk `.in.enc` and `.out.enc` files are written and read by the
+  backend job flow.
+- `$PROOFS`: user correction JSON files and uploaded PDFs are written under a
+  filesystem tree that is also scanned by backend code.
+
+Keeping these paths on pod-local disk makes results and proofs disappear when a
+pod is replaced. Moving everything immediately to S3 would be cleaner long term
+for some flows, but it requires larger application refactors. RWX gives the
+Kubernetes migration a smaller step: preserve filesystem semantics while making
+the backing store shared and restart-resilient.
+
+## Architecture
+
+Add one RWX PersistentVolumeClaim for backend runtime files in the `poc` and
+future `dev` overlays. Mount it into the backend pod at a stable path, then
+derive:
+
+- `JOBS=/var/lib/matchid/jobs`
+- `PROOFS=/var/lib/matchid/proofs`
+
+The initial implementation can use one PVC with two subdirectories. If
+operational needs diverge, split into two PVCs later:
+
+- `jobs-rwx`: high churn, short retention, cleanup-heavy.
+- `proofs-rwx`: lower churn, longer retention, user-facing durability.
+
+The API and any future dedicated worker Deployment must mount the same PVC at
+the same path. Redis remains the source of truth for whether a job is stopped,
+which input/output path belongs to a job, and which cleanup/retry action is
+pending.
+
+## Data Flow
+
+Bulk upload:
+
+1. API receives the uploaded file.
+2. API writes encrypted input to `$JOBS/<jobId>.in.enc` on RWX storage.
+3. API records metadata in Redis, including job id, input path, status, and
+   timestamps.
+4. Worker reads input from RWX storage and writes `$JOBS/<jobId>.out.enc`.
+5. Worker updates Redis with completion state and output metadata.
+6. API serves result download from RWX storage.
+7. Cleanup deletes expired job files and clears Redis metadata.
+
+Proof / correction upload:
+
+1. API writes correction JSON and PDFs under `$PROOFS/<recordId>/`.
+2. Backend refresh strategy is made explicit: either reload on demand, watch the
+   RWX tree, or move correction indexing into a small Redis-backed invalidation
+   path.
+3. Backup sync copies proofs to S3 on a scheduled or event-driven basis.
+
+## Failure Handling
+
+RWX mount unavailable:
+
+- Backend startup/readiness should fail if `JOBS` or `PROOFS` is not writable.
+- Pods should not accept bulk uploads while the mount is unavailable.
+
+Pod restart during bulk processing:
+
+- Files remain on RWX storage.
+- Redis job metadata decides whether the job can be retried, resumed, or marked
+  failed.
+- A graceful shutdown path should stop accepting new work and let in-flight jobs
+  drain when possible.
+
+RWX data loss or corruption:
+
+- `JOBS` is recoverable only within its retention window; outputs can be
+  regenerated if input and job metadata remain valid.
+- `PROOFS` must be backed up to S3 because it is user-facing durable data.
+
+Concurrent pods:
+
+- Filesystem paths are shared, but coordination must not rely on files alone.
+- Redis owns locks, stop flags, status, retries, and cleanup markers.
+
+## Kubernetes Scope
+
+First target:
+
+- `deploy/k8s/overlays/poc`
+- later `dev` long-lived overlay when the platform contract is stable
+
+Required manifest changes:
+
+- Add Scaleway RWX StorageClass/PVC wiring for File Storage.
+- Mount the PVC in `deces-backend`.
+- Set backend env vars for `JOBS` and `PROOFS`.
+- Add startup/readiness checks for writable paths.
+- Keep local/k3d using hostPath or local PVC equivalent for smoke tests.
+
+Do not change production storage until the POC has passed restart and cleanup
+tests.
+
+## Out Of Scope
+
+- Moving OTP, rate limits, ban IP, stop flags, and job metadata into files.
+- Running Elasticsearch data on RWX File Storage.
+- Replacing S3 snapshots or dataprep artifact publication.
+- Solving the current `dataprep year remote-all` SSH failure.
+- Full Surch replacement of Elasticsearch.
+
+## Validation
+
+POC acceptance checks:
+
+- Backend pod starts only when RWX mount is writable.
+- Bulk upload survives backend pod restart before processing.
+- Bulk result survives backend pod restart after processing.
+- A second backend or worker pod can read files written by the first pod.
+- `PROOFS` writes survive pod restart.
+- Cleanup removes expired `JOBS` files without touching `PROOFS`.
+- Redis remains the only state/coordination source for job metadata.
+- S3 backup path for `PROOFS` is tested before any production use.
+
+Non-goals for the first spike:
+
+- Multi-zone durability guarantees.
+- Full production cutover.
+- New application-level S3 file API.
+
+## Rollout Plan
+
+1. Prototype RWX PVC in `poc` overlay.
+2. Mount it in `deces-backend` and wire `JOBS` / `PROOFS`.
+3. Add writeability probes and smoke checks.
+4. Run restart tests for API and future worker topology.
+5. Add Redis-backed bulk metadata before scaling workers.
+6. Add S3 backup/retention for `PROOFS`.
+7. Reassess whether `JOBS` should stay RWX or move partly to S3 after the
+   worker split is complete.
+
+## Open Risks
+
+- Scaleway File Storage is in public beta; availability and performance must be
+  validated before production dependence.
+- RWX preserves filesystem semantics, including possible contention and cleanup
+  races; Redis coordination is mandatory.
+- `updatedFields` currently loads from `PROOFS` at startup, so multi-pod
+  correctness still needs a reload/invalidation design.
+- The CD `dataprep year` path still depends on a VM over SSH and failed after
+  the PR #59 merge; that is a separate reliability track.


### PR DESCRIPTION
## Summary
- add a backend runtime RWX PVC for JOBS and PROOFS
- mount it in deces-backend with init/readiness writability checks
- add local hostPath RWX wiring and PoC StorageClass contract for matchid-rwx

## Validation
- kubectl kustomize deploy/k8s/overlays/local
- kubectl kustomize deploy/k8s/overlays/poc

## Notes
The current PoC cluster exposes only block StorageClasses (scw-bssd / sbs-*). Before scaling deces-backend on PoC, poc-k8s needs a matchid-rwx StorageClass backed by Scaleway File Storage RWX.