### PR TITLE
fix(cd): route remote SSH through bastion

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -335,6 +335,8 @@ jobs:
       RECIPE_THREADS: 16
       RECIPE_QUEUE: 18
       ES_MEM: 30000m
+      # SSH through the existing proxy instead of tracking GitHub-hosted runner CIDRs.
+      CLOUD_SSHOPTS: ${{ vars.CLOUD_SSHOPTS || '-J ubuntu@163.172.185.238 -o IdentitiesOnly=yes' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -431,6 +433,8 @@ jobs:
       RECIPE_THREADS: 32
       RECIPE_QUEUE: 34
       ES_MEM: 62000m
+      # SSH through the existing proxy instead of tracking GitHub-hosted runner CIDRs.
+      CLOUD_SSHOPTS: ${{ vars.CLOUD_SSHOPTS || '-J ubuntu@163.172.185.238 -o IdentitiesOnly=yes' }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -547,6 +551,8 @@ jobs:
       APP_DNS: deces.matchid.io
       GIT_BRANCH: ${{ github.event.client_payload.ref || github.ref_name }}
       DEPLOY_TARGET: ${{ github.event.inputs.deploy_target || 'none' }}
+      # SSH through the existing proxy instead of tracking GitHub-hosted runner CIDRs.
+      CLOUD_SSHOPTS: ${{ vars.CLOUD_SSHOPTS || '-J ubuntu@163.172.185.238 -o IdentitiesOnly=yes' }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary

- routes remote SSH jobs through the existing proxy/bastion (`163.172.185.238`) via `CLOUD_SSHOPTS`
- applies the setting to dataprep year, dataprep full, and remote deploy jobs
- leaves `matchid-private` and `SCW_SERVER_OPTS` unchanged, avoiding a static allowlist of GitHub-hosted runner CIDRs
- allows future override with repository variable `CLOUD_SSHOPTS` if the bastion changes

## Context

The current `matchid-private` security group allows inbound TCP from `163.172.185.238/32` and private IPs, then drops all other TCP. GitHub Actions `/meta` currently lists 6575 `actions` CIDRs, so copying that set into Scaleway would be noisy and brittle. The historical local artifacts already used a ProxyJump path for this deployment family.

## Validation

- `git diff --check`
- Ruby YAML parse of `.github/workflows/cd.yml`
- checked commit metadata: no co-author trailer