### PR TITLE
fix(cd): trust dataprep SSH bastion host key

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -349,6 +349,7 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          ssh-keyscan -T 10 -H 163.172.185.238 >> "${HOME}/.ssh/known_hosts"
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Check dataprep year snapshot
@@ -447,6 +448,7 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          ssh-keyscan -T 10 -H 163.172.185.238 >> "${HOME}/.ssh/known_hosts"
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Check dataprep full snapshot
@@ -565,6 +567,7 @@ jobs:
           chmod 600 "${HOME}/.ssh/id_rsa_matchID"
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
+          ssh-keyscan -T 10 -H 163.172.185.238 >> "${HOME}/.ssh/known_hosts"
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Deploy deces.matchid.io


### PR DESCRIPTION
## Summary
- add the dataprep SSH bastion host key to `known_hosts` in CD jobs before using `ProxyJump`
- apply the same setup to dataprep year, dataprep full, and deploy jobs

## Root cause
The previous CD fix correctly routed SSH through `163.172.185.238`, but the GitHub runner had no trusted host key for that jump host. OpenSSH rejected the bastion before reaching the ephemeral Scaleway VM with `Host key verification failed`.

## Validation
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/cd.yml'); puts 'ok'"`
- `ssh-keyscan -T 10 -H 163.172.185.238` returned RSA/ECDSA/ED25519 host keys