### PR TITLE
fix(cd): configure SSH identity for bastion jump

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -350,6 +350,16 @@ jobs:
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
           ssh-keyscan -T 10 -H 163.172.185.238 >> "${HOME}/.ssh/known_hosts"
+          cat >> "${HOME}/.ssh/config" <<EOF
+          Host bastion 163.172.185.238
+            HostName 163.172.185.238
+            User ubuntu
+            IdentityFile ${HOME}/.ssh/id_rsa_matchID
+            IdentitiesOnly yes
+            BatchMode yes
+            UserKnownHostsFile ${HOME}/.ssh/known_hosts
+          EOF
+          chmod 600 "${HOME}/.ssh/config"
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Check dataprep year snapshot
@@ -449,6 +459,16 @@ jobs:
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
           ssh-keyscan -T 10 -H 163.172.185.238 >> "${HOME}/.ssh/known_hosts"
+          cat >> "${HOME}/.ssh/config" <<EOF
+          Host bastion 163.172.185.238
+            HostName 163.172.185.238
+            User ubuntu
+            IdentityFile ${HOME}/.ssh/id_rsa_matchID
+            IdentitiesOnly yes
+            BatchMode yes
+            UserKnownHostsFile ${HOME}/.ssh/known_hosts
+          EOF
+          chmod 600 "${HOME}/.ssh/config"
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Check dataprep full snapshot
@@ -568,6 +588,16 @@ jobs:
           ssh-keygen -y -f "${HOME}/.ssh/id_rsa_matchID" > "${HOME}/.ssh/id_rsa_matchID.pub"
           chmod 644 "${HOME}/.ssh/id_rsa_matchID.pub"
           ssh-keyscan -T 10 -H 163.172.185.238 >> "${HOME}/.ssh/known_hosts"
+          cat >> "${HOME}/.ssh/config" <<EOF
+          Host bastion 163.172.185.238
+            HostName 163.172.185.238
+            User ubuntu
+            IdentityFile ${HOME}/.ssh/id_rsa_matchID
+            IdentitiesOnly yes
+            BatchMode yes
+            UserKnownHostsFile ${HOME}/.ssh/known_hosts
+          EOF
+          chmod 600 "${HOME}/.ssh/config"
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
       - name: Deploy deces.matchid.io


### PR DESCRIPTION
## Summary
- add an SSH config entry for the dataprep bastion in CD jobs
- force the bastion jump host to use `id_rsa_matchID` with `IdentitiesOnly`/`BatchMode`
- keep the host key scan from #62 for the same bastion host

## Root cause
After #62, the CD no longer failed host-key verification. The next failure was `ubuntu@163.172.185.238: Permission denied`, which means the OpenSSH `ProxyJump` child process was reaching the bastion but was not using the deploy identity configured for the final host.

## Validation
- `git diff --check`
- Ruby YAML parse of `.github/workflows/cd.yml`
- inspected the parsed `Install dataprep deploy SSH key` run block to confirm the heredoc renders without indentation in the shell script