### PR TITLE
fix(cd): preserve prod server on deploy

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -627,6 +627,7 @@ jobs:
             fi
             make deploy-remote \
               GIT_BACKEND_BRANCH=master GIT_BRANCH=$GIT_BRANCH \
+              DEPLOY_DELETE_OLD=false \
               BACKEND_JOB_CONCURRENCY=$BACKEND_JOB_CONCURRENCY_MASTER \
               BACKEND_CHUNK_CONCURRENCY=$BACKEND_CHUNK_CONCURRENCY_MASTER \
               ES_MEM=$ES_MEM_MASTER \

--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,8 @@ export KUBECONFIG=${HOME}/.kube/config
 
 export PROOFS=${DATA_DIR}/proofs
 export MONITOR_DIR = ${APP_FRONTEND}/log/instances/${APP_GROUP}-${APP_FRONTEND}-${GIT_BRANCH}
+export DEPLOY_DELETE_OLD ?= true
+export DEPLOY_PROD_MAX_SERVERS_WHEN_PRESERVING ?= 2
 
 # backup dir
 export BACKUP_DIR = ${APP_PATH}/backup
@@ -495,6 +497,24 @@ deploy-delete-old: ${DATAPREP_VERSION_FILE} ${DATA_VERSION_FILE}
 		APP=${APP_FRONTEND} APP_VERSION=${APP_VERSION} DC_IMAGE_NAME=deces-ui\
 		GIT_BRANCH=${GIT_BRANCH} ${MAKEOVERRIDES}
 
+deploy-remote-prod-instance-limit:
+	@if [ "${GIT_BRANCH}" = "${GIT_BRANCH_MASTER}" ] && [ "${DEPLOY_DELETE_OLD}" = "false" ]; then \
+		if [ -z "${SCW_SECRET_TOKEN}" ]; then \
+			echo "SCW_SECRET_TOKEN is required to enforce prod instance limit"; \
+			exit 1; \
+		fi; \
+		cloud_hostname=$$(echo "${APP_GROUP}-${APP_FRONTEND}-${GIT_BRANCH}" | tr '[:upper:]' '[:lower:]' | tr '_/' '-'); \
+		server_count=$$(curl -s --fail "${SCW_API}/servers" \
+			-H "X-Auth-Token: ${SCW_SECRET_TOKEN}" \
+			-H "Content-Type: application/json" \
+			| jq -r --arg name "$$cloud_hostname" --arg branch "${GIT_BRANCH}" '[.servers[] | select(.name == $$name and ((.tags // []) | index($$branch)) and (.state != "stopped"))] | length'); \
+		if [ "$${server_count}" -ge "${DEPLOY_PROD_MAX_SERVERS_WHEN_PRESERVING}" ]; then \
+			echo "refusing prod deploy: $${server_count} $${cloud_hostname} servers already exist and DEPLOY_DELETE_OLD=false"; \
+			exit 1; \
+		fi; \
+		echo "prod deploy instance limit ok: $${server_count}/${DEPLOY_PROD_MAX_SERVERS_WHEN_PRESERVING} $${cloud_hostname} servers"; \
+	fi
+
 deploy-monitor:
 	@${MAKE} -C ${TOOLS_PATH} remote-install-monitor\
 		MONITOR_BUCKET=${MONITOR_BUCKET} MONITOR_DIR=${MONITOR_DIR}\
@@ -566,7 +586,13 @@ deploy-remote-preflight: config-minimal
 	done; \
 	echo "deploy-remote preflight ok for ${GIT_BRANCH}-${APP_DNS}"
 
-deploy-remote: config-minimal deploy-remote-instance deploy-remote-services deploy-remote-publish deploy-cdn-purge-cache deploy-delete-old deploy-monitor
+DEPLOY_REMOTE_TARGETS = config-minimal deploy-remote-prod-instance-limit deploy-remote-instance deploy-remote-services deploy-remote-publish deploy-cdn-purge-cache
+ifeq ($(DEPLOY_DELETE_OLD),true)
+DEPLOY_REMOTE_TARGETS += deploy-delete-old
+endif
+DEPLOY_REMOTE_TARGETS += deploy-monitor
+
+deploy-remote: ${DEPLOY_REMOTE_TARGETS}
 
 deploy-docker-pull-base: deploy-remote-instance
 	@${MAKE} -C ${TOOLS_PATH} remote-docker-pull DOCKER_IMAGE=node:12.14.0-slim

--- a/spec/prod_deploy_guards_test.sh
+++ b/spec/prod_deploy_guards_test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUT_FILE="$(mktemp)"
+ERR_FILE="$(mktemp)"
+STUB_DIR=""
+trap 'rm -f "${OUT_FILE}" "${ERR_FILE}"; if [[ -n "${STUB_DIR}" ]]; then rm -rf "${STUB_DIR}"; fi' EXIT
+
+if ! make -pn -C "${ROOT_DIR}" deploy-remote \
+  GIT_BRANCH=master \
+  DEPLOY_DELETE_OLD=false \
+  SCW_SECRET_TOKEN=dummy \
+  SCW_PROJECT_ID=dummy \
+  SCW_IMAGE_ID=dummy \
+  STORAGE_ACCESS_KEY=dummy \
+  STORAGE_SECRET_KEY=dummy \
+  TOOLS_STORAGE_ACCESS_KEY=dummy \
+  TOOLS_STORAGE_SECRET_KEY=dummy \
+  LOG_BUCKET=dummy \
+  LOG_DB_BUCKET=dummy \
+  STATS_BUCKET=dummy \
+  PROOFS_BUCKET=dummy \
+  BACKEND_TOKEN_KEY=dummy \
+  BACKEND_TOKEN_PASSWORD=dummy \
+  NGINX_HOST=dummy \
+  NGINX_USER=dummy \
+  CDN_TOKEN=dummy \
+  CDN_ZONE_ID=dummy \
+  NEW_RELIC_INGEST_KEY=dummy \
+  NEW_RELIC_API_KEY=dummy \
+  NEW_RELIC_ACCOUNT_ID=dummy \
+  > "${OUT_FILE}" \
+  2> "${ERR_FILE}"; then
+  cat "${ERR_FILE}" >&2
+  exit 1
+fi
+
+deploy_remote_line="$(awk '/^deploy-remote:/ { print; exit }' "${OUT_FILE}")"
+
+if [[ "${deploy_remote_line}" == *"deploy-delete-old"* ]]; then
+  echo "deploy-remote must not depend on deploy-delete-old when DEPLOY_DELETE_OLD=false" >&2
+  echo "${deploy_remote_line}" >&2
+  exit 1
+fi
+
+if [[ "${deploy_remote_line}" != *"deploy-remote-prod-instance-limit"* ]]; then
+  echo "prod deploy must check the prod instance limit before ordering a server" >&2
+  echo "${deploy_remote_line}" >&2
+  exit 1
+fi
+
+if ! awk '
+  /if \[\[ \( "\$\{GITHUB_EVENT_NAME\}" == "workflow_dispatch" && "\$\{DEPLOY_TARGET\}" == "prod" \) \]\]/ {
+    in_prod = 1
+  }
+  in_prod && /make deploy-remote/ {
+    in_make = 1
+  }
+  in_make && /DEPLOY_DELETE_OLD=false/ {
+    found = 1
+  }
+  in_make && /^          fi$/ {
+    exit
+  }
+  END {
+    exit found ? 0 : 1
+  }
+' "${ROOT_DIR}/.github/workflows/cd.yml"; then
+  echo "prod workflow dispatch must pass DEPLOY_DELETE_OLD=false to deploy-remote" >&2
+  exit 1
+fi
+
+STUB_DIR="$(mktemp -d)"
+cat > "${STUB_DIR}/curl" <<'EOF'
+#!/usr/bin/env bash
+case "${FAKE_SCW_SERVER_SET:-one}" in
+  one)
+    cat <<'JSON'
+{"servers":[{"name":"matchid-deces-ui-master","tags":["master","current"],"state":"running"},{"name":"matchid-deces-ui-dev","tags":["dev","current"],"state":"running"}]}
+JSON
+    ;;
+  two)
+    cat <<'JSON'
+{"servers":[{"name":"matchid-deces-ui-master","tags":["master","current"],"state":"running"},{"name":"matchid-deces-ui-master","tags":["master","previous"],"state":"running"}]}
+JSON
+    ;;
+  *)
+    echo "unsupported FAKE_SCW_SERVER_SET=${FAKE_SCW_SERVER_SET}" >&2
+    exit 1
+    ;;
+esac
+EOF
+chmod +x "${STUB_DIR}/curl"
+
+PATH="${STUB_DIR}:${PATH}" \
+FAKE_SCW_SERVER_SET=one \
+make -s -C "${ROOT_DIR}" deploy-remote-prod-instance-limit \
+  GIT_BRANCH=master \
+  DEPLOY_DELETE_OLD=false \
+  SCW_SECRET_TOKEN=dummy \
+  SCW_API=https://example.invalid \
+  > "${OUT_FILE}"
+
+if ! grep -q "prod deploy instance limit ok: 1/2 matchid-deces-ui-master servers" "${OUT_FILE}"; then
+  echo "prod instance limit should allow a second preserved prod server" >&2
+  cat "${OUT_FILE}" >&2
+  exit 1
+fi
+
+if PATH="${STUB_DIR}:${PATH}" \
+  FAKE_SCW_SERVER_SET=two \
+  make -s -C "${ROOT_DIR}" deploy-remote-prod-instance-limit \
+    GIT_BRANCH=master \
+    DEPLOY_DELETE_OLD=false \
+    SCW_SECRET_TOKEN=dummy \
+    SCW_API=https://example.invalid \
+    > "${OUT_FILE}" 2> "${ERR_FILE}"; then
+  echo "prod instance limit must refuse creating a third preserved prod server" >&2
+  cat "${OUT_FILE}" >&2
+  exit 1
+fi
+
+if ! grep -q "refusing prod deploy: 2 matchid-deces-ui-master servers already exist" "${OUT_FILE}"; then
+  echo "prod instance limit failure message is missing expected server count" >&2
+  cat "${OUT_FILE}" >&2
+  cat "${ERR_FILE}" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- keep prod deploys from running deploy-delete-old when dispatched manually
- refuse a preserved prod deploy when two matchid-deces-ui-master servers already exist
- add a Makefile guard test for the prod deploy path

## Tests
- spec/prod_deploy_guards_test.sh
- git diff --check