### PR TITLE
fix(cd): bound remote ssh and backend probes

### DIFF
--- a/packages/deces-backend/Makefile
+++ b/packages/deces-backend/Makefile
@@ -173,17 +173,18 @@ deploy-dependencies: config
 backend-start: backend-redis
 	@echo docker-compose up backend for production ${VERSION}
 	@export EXEC_ENV=production; ${DC_BACKEND} up -d 2>&1 | grep -v orphan
-	@timeout=${BACKEND_TIMEOUT} ; ret=1 ;\
-		until [ "$$timeout" -le 0 -o "$$ret" -eq "0"  ] ; do\
-			(timeout 5s docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --connect-timeout 2 --max-time 4 --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/healthcheck > /dev/null) ;\
+	@started=$$(date +%s); deadline=$$((started + BACKEND_TIMEOUT)); ret=1 ;\
+		until [ "$$(date +%s)" -ge "$$deadline" -o "$$ret" -eq "0"  ] ; do\
+			(timeout --kill-after=2s 5s docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --connect-timeout 2 --max-time 4 --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/healthcheck > /dev/null) ;\
 			ret=$$? ;\
 			if [ "$$ret" -ne "0" ] ; then\
-				echo -e "try still $$timeout seconds to start backend before timeout" ;\
+				remaining=$$((deadline - $$(date +%s))); if [ "$$remaining" -lt 0 ]; then remaining=0; fi ;\
+				echo -e "try still $$remaining seconds to start backend before timeout" ;\
 			fi ;\
-			((timeout--)); sleep 1 ;\
+			sleep 1 ;\
 		done ;\
 	if [ "$$ret" -ne "0" ]; then docker logs --tail 200 ${APP_BACKEND} || true; fi ;\
-	echo -e "backend started in $$((BACKEND_TIMEOUT - timeout)) seconds"; exit $$ret
+	echo -e "backend started in $$(( $$(date +%s) - started )) seconds"; exit $$ret
 
 backend-stop:
 	@echo docker-compose down backend for production ${VERSION}

--- a/packages/deces-backend/tests/test_backend_startup_probe.sh
+++ b/packages/deces-backend/tests/test_backend_startup_probe.sh
@@ -16,9 +16,12 @@ fail() {
   exit 1
 }
 
-[[ "${target}" == *"timeout 5s docker exec"* ]] || fail "docker exec readiness probe is not command-time bounded"
+[[ "${target}" == *"timeout --kill-after=2s 5s docker exec"* ]] || fail "docker exec readiness probe is not hard-kill bounded"
 [[ "${target}" == *"--connect-timeout 2"* ]] || fail "curl probe is missing a connect timeout"
 [[ "${target}" == *"--max-time 4"* ]] || fail "curl probe is missing a total timeout"
+[[ "${target}" == *'started=$$(date +%s)'* ]] || fail "startup loop does not record wall-clock start time"
+[[ "${target}" == *'deadline=$$((started + BACKEND_TIMEOUT))'* ]] || fail "startup loop is not bounded by wall-clock deadline"
+[[ "${target}" != *'timeout=${BACKEND_TIMEOUT}'* ]] || fail "startup loop still treats retry count as elapsed seconds"
 [[ "${target}" == *"/deces/api/v1/healthcheck"* ]] || fail "startup probe must use healthcheck, not a version endpoint backed by Elasticsearch"
 [[ "${target}" != *"/deces/api/v1/version"* ]] || fail "startup probe still depends on the version endpoint"
 [[ "${target}" == *"docker logs --tail 200 \${APP_BACKEND}"* ]] || fail "backend logs are not dumped on startup failure"

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -85,6 +85,7 @@ SSHKEY_PRIVATE = ${HOME}/.ssh/id_rsa_${APP_GROUP}
 SSHKEY = ${SSHKEY_PRIVATE}.pub
 SSHKEYNAME = ${TOOLS}
 SSH_TIMEOUT = 90
+SSH_CONNECT_TIMEOUT = 5
 
 export CURL_OPTS = --retry 5 --retry-delay 2 -A "GitHub Actions"
 
@@ -120,7 +121,7 @@ endif
 dummy		    := $(shell touch artifacts)
 include ./artifacts
 
-SSHOPTS=-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
+SSHOPTS=-o StrictHostKeyChecking=no -o ConnectTimeout=${SSH_CONNECT_TIMEOUT} -o ConnectionAttempts=1 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
 # Nginx publication must connect directly to the bastion/nginx host, even when
 # the runner injects a global ~/.ssh/config ProxyJump for SCW instances.
 NGINX_SSHOPTS=-F /dev/null -o ProxyJump=none -o StrictHostKeyChecking=no -i ${SSHKEY_PRIVATE}
@@ -450,7 +451,7 @@ ${CLOUD}-instance-wait-ssh: ${CLOUD_FIRST_USER_FILE} ${CLOUD_HOST_FILE}
 			if [ "$$ret" -ne "0" ] ; then\
 				echo -en "\rwaiting for ssh service on ${CLOUD} instance - $$timeout" ; \
 				if [ ! -z "${VERBOSE}" ];then\
-					echo 'cmd: ssh ${SSHOPTS} -o ConnectTimeout=1 '"$$SSHUSER@$$HOST"; \
+					echo 'cmd: ssh ${SSHOPTS} '"$$SSHUSER@$$HOST"; \
 				fi;\
 			fi ;\
 			((timeout--)); sleep 1 ; \
@@ -1400,3 +1401,6 @@ ${GIT_BACKEND}:
 # tests for automation
 remote-config-test:
 	@/usr/bin/time -f %e make remote-actions ACTIONS="generate-test-file storage-push" remote-clean ${MAKEOVERRIDES}
+
+test-remote-ssh-timeouts:
+	@bash ${TOOLS_PATH}/tests/test_remote_ssh_timeouts.sh ${TOOLS_PATH}/Makefile

--- a/packages/tools/tests/test_remote_ssh_timeouts.sh
+++ b/packages/tools/tests/test_remote_ssh_timeouts.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+makefile="${1:-packages/tools/Makefile}"
+
+fail() {
+  printf 'remote ssh timeout check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+content="$(cat "$makefile")"
+
+grep -q '^SSH_CONNECT_TIMEOUT = 5$' <<<"$content" \
+  || fail "SSH_CONNECT_TIMEOUT default is missing"
+
+grep -q 'SSHOPTS=.*-o ConnectTimeout=${SSH_CONNECT_TIMEOUT}' <<<"$content" \
+  || fail "SSHOPTS does not bound SSH connect/banner wait"
+
+grep -q 'SSHOPTS=.*-o ConnectionAttempts=1' <<<"$content" \
+  || fail "SSHOPTS does not disable repeated SSH connection attempts"
+
+grep -q 'cmd: ssh ${SSHOPTS}' <<<"$content" \
+  || fail "verbose wait-ssh command does not reflect SSHOPTS"
+
+if grep -q 'cmd: ssh ${SSHOPTS} -o ConnectTimeout=1' <<<"$content"; then
+  fail "verbose wait-ssh command still advertises stale ConnectTimeout=1"
+fi
+
+printf 'remote ssh timeout check: ok\n'


### PR DESCRIPTION
## Summary
- add connect/banner bounds to shared remote SSH options
- hard-kill backend startup docker exec probes and use a wall-clock startup deadline
- add shell regression checks for both deploy guardrails

## Verification
- bash -n packages/tools/tests/test_remote_ssh_timeouts.sh && bash -n packages/deces-backend/tests/test_backend_startup_probe.sh
- make -C packages/tools test-remote-ssh-timeouts
- make -C packages/deces-backend test-backend-startup-probe
- make -n -C packages/tools SCW-instance-wait-ssh VERBOSE=1
- make -n -C packages/deces-backend backend-start BACKEND_TIMEOUT=10
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Strengthened backend startup probe tests to verify timeout and deadline behavior
  * Added SSH timeout configuration verification tests

* **Chores**
  * Improved backend startup reliability with enhanced timeout handling and deadline computation
  * Enhanced SSH connection timeout configuration with centralized settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matchID-project/matchID/pull/69?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->