### PR TITLE
fix(cd): avoid backend docker exec readiness hangs

### DIFF
--- a/packages/deces-backend/Makefile
+++ b/packages/deces-backend/Makefile
@@ -175,8 +175,13 @@ backend-start: backend-redis
 	@export EXEC_ENV=production; ${DC_BACKEND} up -d 2>&1 | grep -v orphan
 	@started=$$(date +%s); deadline=$$((started + BACKEND_TIMEOUT)); ret=1 ;\
 		until [ "$$(date +%s)" -ge "$$deadline" -o "$$ret" -eq "0"  ] ; do\
-			(timeout --kill-after=2s 5s docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --connect-timeout 2 --max-time 4 --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/healthcheck > /dev/null) ;\
-			ret=$$? ;\
+			backend_ip=$$(timeout --kill-after=2s 5s docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${APP_BACKEND} 2>/dev/null || true) ;\
+			if [ -n "$$backend_ip" ] ; then\
+				curl --noproxy '*' -s --connect-timeout 2 --max-time 4 --fail -X GET "http://$$backend_ip:${BACKEND_PORT}/deces/api/v1/healthcheck" > /dev/null ;\
+				ret=$$? ;\
+			else\
+				ret=1 ;\
+			fi ;\
 			if [ "$$ret" -ne "0" ] ; then\
 				remaining=$$((deadline - $$(date +%s))); if [ "$$remaining" -lt 0 ]; then remaining=0; fi ;\
 				echo -e "try still $$remaining seconds to start backend before timeout" ;\

--- a/packages/deces-backend/tests/test_backend_startup_probe.sh
+++ b/packages/deces-backend/tests/test_backend_startup_probe.sh
@@ -16,7 +16,10 @@ fail() {
   exit 1
 }
 
-[[ "${target}" == *"timeout --kill-after=2s 5s docker exec"* ]] || fail "docker exec readiness probe is not hard-kill bounded"
+[[ "${target}" != *"docker exec"* ]] || fail "backend-start still uses docker exec for readiness"
+[[ "${target}" == *"timeout --kill-after=2s 5s docker inspect -f"* ]] || fail "container IP lookup is not bounded"
+[[ "${target}" == *"backend_ip="* ]] || fail "startup loop does not resolve the backend container IP"
+[[ "${target}" == *"curl --noproxy '*'"* ]] || fail "host readiness probe must bypass proxies"
 [[ "${target}" == *"--connect-timeout 2"* ]] || fail "curl probe is missing a connect timeout"
 [[ "${target}" == *"--max-time 4"* ]] || fail "curl probe is missing a total timeout"
 [[ "${target}" == *'started=$$(date +%s)'* ]] || fail "startup loop does not record wall-clock start time"

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -86,6 +86,7 @@ SSHKEY = ${SSHKEY_PRIVATE}.pub
 SSHKEYNAME = ${TOOLS}
 SSH_TIMEOUT = 90
 SSH_CONNECT_TIMEOUT = 5
+REMOTE_ACTION_TIMEOUT ?= 1800
 
 export CURL_OPTS = --retry 5 --retry-delay 2 -A "GitHub Actions"
 
@@ -1274,7 +1275,7 @@ remote-actions: remote-deploy
 			else\
 				MAKE_APP_PATH=${REMOTE_TOOLS_MAKE_PATH};\
 			fi;\
-			REMOTE_CMD=$$(printf '%q ' make -C "$$MAKE_APP_PATH" ${ACTIONS} STORAGE_ACCESS_KEY="${STORAGE_ACCESS_KEY}" STORAGE_SECRET_KEY="${STORAGE_SECRET_KEY}" ${REMOTE_ACTION_MAKEOVERRIDES}); ssh ${SSHOPTS} $$U@$$H "$$REMOTE_CMD";\
+			REMOTE_CMD=$$(printf '%q ' make -C "$$MAKE_APP_PATH" ${ACTIONS} STORAGE_ACCESS_KEY="${STORAGE_ACCESS_KEY}" STORAGE_SECRET_KEY="${STORAGE_SECRET_KEY}" ${REMOTE_ACTION_MAKEOVERRIDES}); timeout --kill-after=30s ${REMOTE_ACTION_TIMEOUT}s ssh ${SSHOPTS} $$U@$$H "$$REMOTE_CMD";\
 		fi
 
 remote-test-api-in-vpc: ${CLOUD}-instance-get-tagged-hosts

--- a/packages/tools/tests/test_remote_ssh_timeouts.sh
+++ b/packages/tools/tests/test_remote_ssh_timeouts.sh
@@ -13,6 +13,9 @@ content="$(cat "$makefile")"
 grep -q '^SSH_CONNECT_TIMEOUT = 5$' <<<"$content" \
   || fail "SSH_CONNECT_TIMEOUT default is missing"
 
+grep -q '^REMOTE_ACTION_TIMEOUT ?= 1800$' <<<"$content" \
+  || fail "REMOTE_ACTION_TIMEOUT default is missing"
+
 grep -q 'SSHOPTS=.*-o ConnectTimeout=${SSH_CONNECT_TIMEOUT}' <<<"$content" \
   || fail "SSHOPTS does not bound SSH connect/banner wait"
 
@@ -25,5 +28,8 @@ grep -q 'cmd: ssh ${SSHOPTS}' <<<"$content" \
 if grep -q 'cmd: ssh ${SSHOPTS} -o ConnectTimeout=1' <<<"$content"; then
   fail "verbose wait-ssh command still advertises stale ConnectTimeout=1"
 fi
+
+grep -q 'timeout --kill-after=30s ${REMOTE_ACTION_TIMEOUT}s ssh ${SSHOPTS}' <<<"$content" \
+  || fail "remote-actions SSH session is not wall-clock bounded"
 
 printf 'remote ssh timeout check: ok\n'


### PR DESCRIPTION
## Summary
- probe backend readiness from the host via the backend container IP instead of docker exec
- keep curl/connect deadlines and wall-clock backend startup deadline
- add a wall-clock timeout around remote-actions SSH sessions

## Tests
- make -C packages/deces-backend test-backend-startup-probe
- make -C packages/tools test-remote-ssh-timeouts
- bash -n packages/deces-backend/tests/test_backend_startup_probe.sh
- bash -n packages/tools/tests/test_remote_ssh_timeouts.sh
- make -n -C packages/deces-backend backend-start BACKEND_TIMEOUT=10
- make -n -C packages/tools remote-actions ACTIONS=deploy-local
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified backend startup health check to verify container status from the host system instead of inside the container.
  * Added configurable timeout protection for remote operations with a 30-minute default duration and automatic termination after a 30-second grace period.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matchID-project/matchID/pull/70?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->