### PR TITLE
fix(cd): publish only current Scaleway instance

### DIFF
--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -790,24 +790,39 @@ SCW-instance-image: ${CLOUD_SNAPSHOT_ID_FILE}.done
 
 SCW-instance-get-tagged-ids: ${CLOUD_DIR}
 	if [ ! -f "${CLOUD_TAGGED_IDS_FILE}" ];then\
-		curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
-			| jq -cr '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (.tags[1] | contains("${CLOUD_TAG}"))) | .id'\
-			> ${CLOUD_TAGGED_IDS_FILE};\
+		CURRENT_SCW_SERVER_ID=$$(cat ${CLOUD_SERVER_ID_FILE} 2>/dev/null || true);\
+		if [ -n "$$CURRENT_SCW_SERVER_ID" ]; then\
+			curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
+				| jq -cr --arg current "$$CURRENT_SCW_SERVER_ID" '.servers[] | select(.id == $$current) | .id'\
+				> ${CLOUD_TAGGED_IDS_FILE};\
+		else\
+			curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
+				| jq -cr '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (.tags[1] | contains("${CLOUD_TAG}"))) | .id'\
+				> ${CLOUD_TAGGED_IDS_FILE};\
+		fi;\
 	fi
 
 SCW-instance-get-tagged-ids-invalid: ${CLOUD_DIR}
 	@if [ ! -f "${CLOUD_TAGGED_IDS_INVALID_FILE}" ];then\
+		CURRENT_SCW_SERVER_ID=$$(cat ${CLOUD_SERVER_ID_FILE} 2>/dev/null || true);\
 		curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
-			| jq -cr '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (.tags[1] | contains("${CLOUD_TAG}") | not)) | .id'\
+			| jq -cr --arg current "$$CURRENT_SCW_SERVER_ID" '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (((.tags[1] | contains("${CLOUD_TAG}")) | not) or (($$current != "") and (.id != $$current)))) | .id'\
 			> ${CLOUD_TAGGED_IDS_INVALID_FILE};\
 	fi
 
 SCW-instance-get-tagged-hosts: SCW-instance-get-tagged-ids
 	@\
 	if [ ! -f "${CLOUD_TAGGED_HOSTS_FILE}" ];then\
+			CURRENT_SCW_SERVER_ID=$$(cat ${CLOUD_SERVER_ID_FILE} 2>/dev/null || true);\
+			if [ -n "$$CURRENT_SCW_SERVER_ID" ]; then\
+				curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
+					| jq -cr --arg current "$$CURRENT_SCW_SERVER_ID" '.servers[] | select(.id == $$current) | .${SCW_IP}'\
+					> ${CLOUD_TAGGED_HOSTS_FILE};\
+			else\
 			curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
 				| jq -cr '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (.tags[1] | contains("${CLOUD_TAG}"))) | .${SCW_IP}'\
 				> ${CLOUD_TAGGED_HOSTS_FILE};\
+			fi;\
 	fi;
 	@\
 	if [ ! -z "${SCW_PRIVATE_NETWORK_ID"}" -a ! -f "${CLOUD_TAGGED_HOSTS_VPC_FILE}"  ]; then\
@@ -1405,3 +1420,6 @@ remote-config-test:
 
 test-remote-ssh-timeouts:
 	@bash ${TOOLS_PATH}/tests/test_remote_ssh_timeouts.sh ${TOOLS_PATH}/Makefile
+
+test-current-instance-publish:
+	@bash ${TOOLS_PATH}/tests/test_current_instance_publish.sh ${TOOLS_PATH}/Makefile

--- a/packages/tools/tests/test_current_instance_publish.sh
+++ b/packages/tools/tests/test_current_instance_publish.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+makefile="${1:-packages/tools/Makefile}"
+
+fail() {
+  printf 'current instance publish check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+content="$(cat "$makefile")"
+
+grep -q 'CURRENT_SCW_SERVER_ID=$$(cat ${CLOUD_SERVER_ID_FILE} 2>/dev/null || true)' <<<"$content" \
+  || fail "tagged host resolution does not read the current SCW server id"
+
+grep -q 'select(.id == $$current)' <<<"$content" \
+  || fail "tagged host resolution does not prefer the current SCW server"
+
+grep -q -- '--arg current "$$CURRENT_SCW_SERVER_ID"' <<<"$content" \
+  || fail "SCW jq filters do not receive the current server id"
+
+grep -q '(.id != $$current)' <<<"$content" \
+  || fail "invalid cleanup does not exclude the current SCW server"
+
+grep -q 'test-current-instance-publish:' <<<"$content" \
+  || fail "Makefile target for current instance publish test is missing"
+
+printf 'current instance publish check: ok\n'


### PR DESCRIPTION
## Summary
- make SCW tagged-host resolution prefer the VM created by the current deploy run
- make invalid cleanup delete older same-branch instances once a current server id exists
- add a regression test for current-instance publish semantics

## Tests
- make -C packages/tools test-current-instance-publish
- make -C packages/tools test-remote-ssh-timeouts
- bash -n packages/tools/tests/test_current_instance_publish.sh
- make -n -C packages/tools SCW-instance-get-tagged-hosts SCW-instance-delete-invalid GIT_BRANCH=dev CLOUD_TAG=ui:test APP=deces-ui
- git diff --check