### PR TITLE
fix(cd): bound SSH/backend probes + publish only current instance

### DIFF
--- a/packages/deces-backend/Makefile
+++ b/packages/deces-backend/Makefile
@@ -173,17 +173,18 @@ deploy-dependencies: config
 backend-start: backend-redis
 	@echo docker-compose up backend for production ${VERSION}
 	@export EXEC_ENV=production; ${DC_BACKEND} up -d 2>&1 | grep -v orphan
-	@timeout=${BACKEND_TIMEOUT} ; ret=1 ;\
-		until [ "$$timeout" -le 0 -o "$$ret" -eq "0"  ] ; do\
-			(timeout 5s docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --connect-timeout 2 --max-time 4 --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/healthcheck > /dev/null) ;\
+	@started=$$(date +%s); deadline=$$((started + BACKEND_TIMEOUT)); ret=1 ;\
+		until [ "$$(date +%s)" -ge "$$deadline" -o "$$ret" -eq "0"  ] ; do\
+			(timeout --kill-after=2s 5s docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --connect-timeout 2 --max-time 4 --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/healthcheck > /dev/null) ;\
 			ret=$$? ;\
 			if [ "$$ret" -ne "0" ] ; then\
-				echo -e "try still $$timeout seconds to start backend before timeout" ;\
+				remaining=$$((deadline - $$(date +%s))); if [ "$$remaining" -lt 0 ]; then remaining=0; fi ;\
+				echo -e "try still $$remaining seconds to start backend before timeout" ;\
 			fi ;\
-			((timeout--)); sleep 1 ;\
+			sleep 1 ;\
 		done ;\
 	if [ "$$ret" -ne "0" ]; then docker logs --tail 200 ${APP_BACKEND} || true; fi ;\
-	echo -e "backend started in $$((BACKEND_TIMEOUT - timeout)) seconds"; exit $$ret
+	echo -e "backend started in $$(( $$(date +%s) - started )) seconds"; exit $$ret
 
 backend-stop:
 	@echo docker-compose down backend for production ${VERSION}

--- a/packages/deces-backend/Makefile
+++ b/packages/deces-backend/Makefile
@@ -118,6 +118,9 @@ version:
 
 version-files:
 	@cd ${BACKEND_PATH} && export LC_COLLATE=C; export LC_ALL=C; cat tagfiles.version | xargs -I '{}' find {} -type f | egrep -v '.tar.gz$$|.pyc$$|.gitignore$$' | sort
+
+test-backend-startup-probe:
+	@bash ${BACKEND_PATH}/tests/test_backend_startup_probe.sh ${BACKEND_PATH}/Makefile
 endif
 
 
@@ -172,13 +175,14 @@ backend-start: backend-redis
 	@export EXEC_ENV=production; ${DC_BACKEND} up -d 2>&1 | grep -v orphan
 	@timeout=${BACKEND_TIMEOUT} ; ret=1 ;\
 		until [ "$$timeout" -le 0 -o "$$ret" -eq "0"  ] ; do\
-			(docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/version > /dev/null) ;\
+			(timeout 5s docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --connect-timeout 2 --max-time 4 --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/healthcheck > /dev/null) ;\
 			ret=$$? ;\
 			if [ "$$ret" -ne "0" ] ; then\
 				echo -e "try still $$timeout seconds to start backend before timeout" ;\
 			fi ;\
 			((timeout--)); sleep 1 ;\
 		done ;\
+	if [ "$$ret" -ne "0" ]; then docker logs --tail 200 ${APP_BACKEND} || true; fi ;\
 	echo -e "backend started in $$((BACKEND_TIMEOUT - timeout)) seconds"; exit $$ret
 
 backend-stop:

--- a/packages/deces-backend/Makefile
+++ b/packages/deces-backend/Makefile
@@ -175,8 +175,13 @@ backend-start: backend-redis
 	@export EXEC_ENV=production; ${DC_BACKEND} up -d 2>&1 | grep -v orphan
 	@started=$$(date +%s); deadline=$$((started + BACKEND_TIMEOUT)); ret=1 ;\
 		until [ "$$(date +%s)" -ge "$$deadline" -o "$$ret" -eq "0"  ] ; do\
-			(timeout --kill-after=2s 5s docker exec -i ${USE_TTY} ${APP_BACKEND} curl -s --connect-timeout 2 --max-time 4 --fail -X GET http://localhost:${BACKEND_PORT}/deces/api/v1/healthcheck > /dev/null) ;\
-			ret=$$? ;\
+			backend_ip=$$(timeout --kill-after=2s 5s docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' ${APP_BACKEND} 2>/dev/null || true) ;\
+			if [ -n "$$backend_ip" ] ; then\
+				curl --noproxy '*' -s --connect-timeout 2 --max-time 4 --fail -X GET "http://$$backend_ip:${BACKEND_PORT}/deces/api/v1/healthcheck" > /dev/null ;\
+				ret=$$? ;\
+			else\
+				ret=1 ;\
+			fi ;\
 			if [ "$$ret" -ne "0" ] ; then\
 				remaining=$$((deadline - $$(date +%s))); if [ "$$remaining" -lt 0 ]; then remaining=0; fi ;\
 				echo -e "try still $$remaining seconds to start backend before timeout" ;\

--- a/packages/deces-backend/tests/test_backend_startup_probe.sh
+++ b/packages/deces-backend/tests/test_backend_startup_probe.sh
@@ -16,7 +16,10 @@ fail() {
   exit 1
 }
 
-[[ "${target}" == *"timeout --kill-after=2s 5s docker exec"* ]] || fail "docker exec readiness probe is not hard-kill bounded"
+[[ "${target}" != *"docker exec"* ]] || fail "backend-start still uses docker exec for readiness"
+[[ "${target}" == *"timeout --kill-after=2s 5s docker inspect -f"* ]] || fail "container IP lookup is not bounded"
+[[ "${target}" == *"backend_ip="* ]] || fail "startup loop does not resolve the backend container IP"
+[[ "${target}" == *"curl --noproxy '*'"* ]] || fail "host readiness probe must bypass proxies"
 [[ "${target}" == *"--connect-timeout 2"* ]] || fail "curl probe is missing a connect timeout"
 [[ "${target}" == *"--max-time 4"* ]] || fail "curl probe is missing a total timeout"
 [[ "${target}" == *'started=$$(date +%s)'* ]] || fail "startup loop does not record wall-clock start time"

--- a/packages/deces-backend/tests/test_backend_startup_probe.sh
+++ b/packages/deces-backend/tests/test_backend_startup_probe.sh
@@ -16,9 +16,12 @@ fail() {
   exit 1
 }
 
-[[ "${target}" == *"timeout 5s docker exec"* ]] || fail "docker exec readiness probe is not command-time bounded"
+[[ "${target}" == *"timeout --kill-after=2s 5s docker exec"* ]] || fail "docker exec readiness probe is not hard-kill bounded"
 [[ "${target}" == *"--connect-timeout 2"* ]] || fail "curl probe is missing a connect timeout"
 [[ "${target}" == *"--max-time 4"* ]] || fail "curl probe is missing a total timeout"
+[[ "${target}" == *'started=$$(date +%s)'* ]] || fail "startup loop does not record wall-clock start time"
+[[ "${target}" == *'deadline=$$((started + BACKEND_TIMEOUT))'* ]] || fail "startup loop is not bounded by wall-clock deadline"
+[[ "${target}" != *'timeout=${BACKEND_TIMEOUT}'* ]] || fail "startup loop still treats retry count as elapsed seconds"
 [[ "${target}" == *"/deces/api/v1/healthcheck"* ]] || fail "startup probe must use healthcheck, not a version endpoint backed by Elasticsearch"
 [[ "${target}" != *"/deces/api/v1/version"* ]] || fail "startup probe still depends on the version endpoint"
 [[ "${target}" == *"docker logs --tail 200 \${APP_BACKEND}"* ]] || fail "backend logs are not dumped on startup failure"

--- a/packages/deces-backend/tests/test_backend_startup_probe.sh
+++ b/packages/deces-backend/tests/test_backend_startup_probe.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+makefile="${1:-packages/deces-backend/Makefile}"
+
+target="$(
+  awk '
+    /^backend-start:/ { inside = 1; print; next }
+    inside && /^[^[:space:]#][^:]*:/ { exit }
+    inside { print }
+  ' "${makefile}"
+)"
+
+fail() {
+  printf 'backend-start probe check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+[[ "${target}" == *"timeout 5s docker exec"* ]] || fail "docker exec readiness probe is not command-time bounded"
+[[ "${target}" == *"--connect-timeout 2"* ]] || fail "curl probe is missing a connect timeout"
+[[ "${target}" == *"--max-time 4"* ]] || fail "curl probe is missing a total timeout"
+[[ "${target}" == *"/deces/api/v1/healthcheck"* ]] || fail "startup probe must use healthcheck, not a version endpoint backed by Elasticsearch"
+[[ "${target}" != *"/deces/api/v1/version"* ]] || fail "startup probe still depends on the version endpoint"
+[[ "${target}" == *"docker logs --tail 200 \${APP_BACKEND}"* ]] || fail "backend logs are not dumped on startup failure"
+
+printf 'backend-start probe check: ok\n'

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -790,24 +790,39 @@ SCW-instance-image: ${CLOUD_SNAPSHOT_ID_FILE}.done
 
 SCW-instance-get-tagged-ids: ${CLOUD_DIR}
 	if [ ! -f "${CLOUD_TAGGED_IDS_FILE}" ];then\
-		curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
-			| jq -cr '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (.tags[1] | contains("${CLOUD_TAG}"))) | .id'\
-			> ${CLOUD_TAGGED_IDS_FILE};\
+		CURRENT_SCW_SERVER_ID=$$(cat ${CLOUD_SERVER_ID_FILE} 2>/dev/null || true);\
+		if [ -n "$$CURRENT_SCW_SERVER_ID" ]; then\
+			curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
+				| jq -cr --arg current "$$CURRENT_SCW_SERVER_ID" '.servers[] | select(.id == $$current) | .id'\
+				> ${CLOUD_TAGGED_IDS_FILE};\
+		else\
+			curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
+				| jq -cr '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (.tags[1] | contains("${CLOUD_TAG}"))) | .id'\
+				> ${CLOUD_TAGGED_IDS_FILE};\
+		fi;\
 	fi
 
 SCW-instance-get-tagged-ids-invalid: ${CLOUD_DIR}
 	@if [ ! -f "${CLOUD_TAGGED_IDS_INVALID_FILE}" ];then\
+		CURRENT_SCW_SERVER_ID=$$(cat ${CLOUD_SERVER_ID_FILE} 2>/dev/null || true);\
 		curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
-			| jq -cr '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (.tags[1] | contains("${CLOUD_TAG}") | not)) | .id'\
+			| jq -cr --arg current "$$CURRENT_SCW_SERVER_ID" '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (((.tags[1] | contains("${CLOUD_TAG}")) | not) or (($$current != "") and (.id != $$current)))) | .id'\
 			> ${CLOUD_TAGGED_IDS_INVALID_FILE};\
 	fi
 
 SCW-instance-get-tagged-hosts: SCW-instance-get-tagged-ids
 	@\
 	if [ ! -f "${CLOUD_TAGGED_HOSTS_FILE}" ];then\
+			CURRENT_SCW_SERVER_ID=$$(cat ${CLOUD_SERVER_ID_FILE} 2>/dev/null || true);\
+			if [ -n "$$CURRENT_SCW_SERVER_ID" ]; then\
+				curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
+					| jq -cr --arg current "$$CURRENT_SCW_SERVER_ID" '.servers[] | select(.id == $$current) | .${SCW_IP}'\
+					> ${CLOUD_TAGGED_HOSTS_FILE};\
+			else\
 			curl -s ${SCW_API}/servers -H "X-Auth-Token: ${SCW_SECRET_TOKEN}" -H "Content-Type: application/json"  \
 				| jq -cr '.servers[] | select(.name=="${CLOUD_HOSTNAME}" and (.tags[0] | contains("${GIT_BRANCH}")) and (.tags[1] | contains("${CLOUD_TAG}"))) | .${SCW_IP}'\
 				> ${CLOUD_TAGGED_HOSTS_FILE};\
+			fi;\
 	fi;
 	@\
 	if [ ! -z "${SCW_PRIVATE_NETWORK_ID"}" -a ! -f "${CLOUD_TAGGED_HOSTS_VPC_FILE}"  ]; then\
@@ -1405,3 +1420,6 @@ remote-config-test:
 
 test-remote-ssh-timeouts:
 	@bash ${TOOLS_PATH}/tests/test_remote_ssh_timeouts.sh ${TOOLS_PATH}/Makefile
+
+test-current-instance-publish:
+	@bash ${TOOLS_PATH}/tests/test_current_instance_publish.sh ${TOOLS_PATH}/Makefile

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -86,6 +86,7 @@ SSHKEY = ${SSHKEY_PRIVATE}.pub
 SSHKEYNAME = ${TOOLS}
 SSH_TIMEOUT = 90
 SSH_CONNECT_TIMEOUT = 5
+REMOTE_ACTION_TIMEOUT ?= 1800
 
 export CURL_OPTS = --retry 5 --retry-delay 2 -A "GitHub Actions"
 
@@ -1274,7 +1275,7 @@ remote-actions: remote-deploy
 			else\
 				MAKE_APP_PATH=${REMOTE_TOOLS_MAKE_PATH};\
 			fi;\
-			REMOTE_CMD=$$(printf '%q ' make -C "$$MAKE_APP_PATH" ${ACTIONS} STORAGE_ACCESS_KEY="${STORAGE_ACCESS_KEY}" STORAGE_SECRET_KEY="${STORAGE_SECRET_KEY}" ${REMOTE_ACTION_MAKEOVERRIDES}); ssh ${SSHOPTS} $$U@$$H "$$REMOTE_CMD";\
+			REMOTE_CMD=$$(printf '%q ' make -C "$$MAKE_APP_PATH" ${ACTIONS} STORAGE_ACCESS_KEY="${STORAGE_ACCESS_KEY}" STORAGE_SECRET_KEY="${STORAGE_SECRET_KEY}" ${REMOTE_ACTION_MAKEOVERRIDES}); timeout --kill-after=30s ${REMOTE_ACTION_TIMEOUT}s ssh ${SSHOPTS} $$U@$$H "$$REMOTE_CMD";\
 		fi
 
 remote-test-api-in-vpc: ${CLOUD}-instance-get-tagged-hosts

--- a/packages/tools/Makefile
+++ b/packages/tools/Makefile
@@ -85,6 +85,7 @@ SSHKEY_PRIVATE = ${HOME}/.ssh/id_rsa_${APP_GROUP}
 SSHKEY = ${SSHKEY_PRIVATE}.pub
 SSHKEYNAME = ${TOOLS}
 SSH_TIMEOUT = 90
+SSH_CONNECT_TIMEOUT = 5
 
 export CURL_OPTS = --retry 5 --retry-delay 2 -A "GitHub Actions"
 
@@ -120,7 +121,7 @@ endif
 dummy		    := $(shell touch artifacts)
 include ./artifacts
 
-SSHOPTS=-o StrictHostKeyChecking=no -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
+SSHOPTS=-o StrictHostKeyChecking=no -o ConnectTimeout=${SSH_CONNECT_TIMEOUT} -o ConnectionAttempts=1 -o ServerAliveInterval=30 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -i ${SSHKEY_PRIVATE} ${CLOUD_SSHOPTS}
 # Nginx publication must connect directly to the bastion/nginx host, even when
 # the runner injects a global ~/.ssh/config ProxyJump for SCW instances.
 NGINX_SSHOPTS=-F /dev/null -o ProxyJump=none -o StrictHostKeyChecking=no -i ${SSHKEY_PRIVATE}
@@ -450,7 +451,7 @@ ${CLOUD}-instance-wait-ssh: ${CLOUD_FIRST_USER_FILE} ${CLOUD_HOST_FILE}
 			if [ "$$ret" -ne "0" ] ; then\
 				echo -en "\rwaiting for ssh service on ${CLOUD} instance - $$timeout" ; \
 				if [ ! -z "${VERBOSE}" ];then\
-					echo 'cmd: ssh ${SSHOPTS} -o ConnectTimeout=1 '"$$SSHUSER@$$HOST"; \
+					echo 'cmd: ssh ${SSHOPTS} '"$$SSHUSER@$$HOST"; \
 				fi;\
 			fi ;\
 			((timeout--)); sleep 1 ; \
@@ -1400,3 +1401,6 @@ ${GIT_BACKEND}:
 # tests for automation
 remote-config-test:
 	@/usr/bin/time -f %e make remote-actions ACTIONS="generate-test-file storage-push" remote-clean ${MAKEOVERRIDES}
+
+test-remote-ssh-timeouts:
+	@bash ${TOOLS_PATH}/tests/test_remote_ssh_timeouts.sh ${TOOLS_PATH}/Makefile

--- a/packages/tools/tests/test_current_instance_publish.sh
+++ b/packages/tools/tests/test_current_instance_publish.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+makefile="${1:-packages/tools/Makefile}"
+
+fail() {
+  printf 'current instance publish check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+content="$(cat "$makefile")"
+
+grep -q 'CURRENT_SCW_SERVER_ID=$$(cat ${CLOUD_SERVER_ID_FILE} 2>/dev/null || true)' <<<"$content" \
+  || fail "tagged host resolution does not read the current SCW server id"
+
+grep -q 'select(.id == $$current)' <<<"$content" \
+  || fail "tagged host resolution does not prefer the current SCW server"
+
+grep -q -- '--arg current "$$CURRENT_SCW_SERVER_ID"' <<<"$content" \
+  || fail "SCW jq filters do not receive the current server id"
+
+grep -q '(.id != $$current)' <<<"$content" \
+  || fail "invalid cleanup does not exclude the current SCW server"
+
+grep -q 'test-current-instance-publish:' <<<"$content" \
+  || fail "Makefile target for current instance publish test is missing"
+
+printf 'current instance publish check: ok\n'

--- a/packages/tools/tests/test_remote_ssh_timeouts.sh
+++ b/packages/tools/tests/test_remote_ssh_timeouts.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+makefile="${1:-packages/tools/Makefile}"
+
+fail() {
+  printf 'remote ssh timeout check failed: %s\n' "$1" >&2
+  exit 1
+}
+
+content="$(cat "$makefile")"
+
+grep -q '^SSH_CONNECT_TIMEOUT = 5$' <<<"$content" \
+  || fail "SSH_CONNECT_TIMEOUT default is missing"
+
+grep -q 'SSHOPTS=.*-o ConnectTimeout=${SSH_CONNECT_TIMEOUT}' <<<"$content" \
+  || fail "SSHOPTS does not bound SSH connect/banner wait"
+
+grep -q 'SSHOPTS=.*-o ConnectionAttempts=1' <<<"$content" \
+  || fail "SSHOPTS does not disable repeated SSH connection attempts"
+
+grep -q 'cmd: ssh ${SSHOPTS}' <<<"$content" \
+  || fail "verbose wait-ssh command does not reflect SSHOPTS"
+
+if grep -q 'cmd: ssh ${SSHOPTS} -o ConnectTimeout=1' <<<"$content"; then
+  fail "verbose wait-ssh command still advertises stale ConnectTimeout=1"
+fi
+
+printf 'remote ssh timeout check: ok\n'

--- a/packages/tools/tests/test_remote_ssh_timeouts.sh
+++ b/packages/tools/tests/test_remote_ssh_timeouts.sh
@@ -13,6 +13,9 @@ content="$(cat "$makefile")"
 grep -q '^SSH_CONNECT_TIMEOUT = 5$' <<<"$content" \
   || fail "SSH_CONNECT_TIMEOUT default is missing"
 
+grep -q '^REMOTE_ACTION_TIMEOUT ?= 1800$' <<<"$content" \
+  || fail "REMOTE_ACTION_TIMEOUT default is missing"
+
 grep -q 'SSHOPTS=.*-o ConnectTimeout=${SSH_CONNECT_TIMEOUT}' <<<"$content" \
   || fail "SSHOPTS does not bound SSH connect/banner wait"
 
@@ -25,5 +28,8 @@ grep -q 'cmd: ssh ${SSHOPTS}' <<<"$content" \
 if grep -q 'cmd: ssh ${SSHOPTS} -o ConnectTimeout=1' <<<"$content"; then
   fail "verbose wait-ssh command still advertises stale ConnectTimeout=1"
 fi
+
+grep -q 'timeout --kill-after=30s ${REMOTE_ACTION_TIMEOUT}s ssh ${SSHOPTS}' <<<"$content" \
+  || fail "remote-actions SSH session is not wall-clock bounded"
 
 printf 'remote ssh timeout check: ok\n'


### PR DESCRIPTION
Replays the CD deploy-resilience fixes (ex-PRs #68/#69/#70/#71) that were reset off `main` along with OTP. They are independent of the OTP work and fix the deploy hangs observed on 2026-05-23/24, where `deploy-dev` froze in `backend-start` for 45 min and was cancelled.

## Why
The dev deploy could hang indefinitely and only get killed by the 45-min job timeout. Two root causes:
1. The backend readiness probe used `docker exec ... curl localhost/version`, which could hang with no bound; and SSH calls to recycled instance IPs had no connect timeout.
2. The Scaleway publish step acted on every same-tag instance, so on a recycled IP it could target a stale/duplicate VM.

## What (cherry-picked, identical to the proven-green state of 2026-05-25)
- `bound backend startup probe` — `backend-start` probes the backend via its container IP with `--connect-timeout/--max-time`, uses a wall-clock deadline, and dumps `docker logs` on failure instead of hanging.
- `bound remote ssh and backend probes` — `SSHOPTS` gains `ConnectTimeout`/`ConnectionAttempts=1`; `remote-actions` wrapped in `timeout --kill-after`.
- `avoid backend docker exec readiness hangs` — replaces the blocking `docker exec` readiness path.
- `publish only current Scaleway instance` — selects only the current server id (anti blue-green duplicate publish).

## Tests
Guard scripts (run locally, all pass):
- `packages/deces-backend/tests/test_backend_startup_probe.sh`
- `packages/tools/tests/test_remote_ssh_timeouts.sh`
- `packages/tools/tests/test_current_instance_publish.sh`

## Relationship to OTP
Independent of PR #72 (OTP + resilient Redis). Both should land before the next dev deploy: #72 makes the backend resilient to Redis restarts; this PR makes the deploy itself not hang. They were proven green together on 2026-05-25 (dev deploy succeeded in 6 min).