### PR TITLE
chore(backend): log resolved Redis target at startup

### DIFF
--- a/packages/deces-backend/src/index.ts
+++ b/packages/deces-backend/src/index.ts
@@ -1,8 +1,12 @@
 import { app } from './server';
+import { logRedisTarget } from './redis';
 
 const port = 8080;
 
 app.listen( port, () => {
   // eslint-disable-next-line no-console
   console.log( `server started at http://localhost:${ port }` );
+  // Surface which Redis the backend actually connects to (single resolved
+  // target shared by OTP and BullMQ) for deploy-time visibility.
+  logRedisTarget();
 } );

--- a/packages/deces-backend/src/redis.spec.ts
+++ b/packages/deces-backend/src/redis.spec.ts
@@ -36,4 +36,13 @@ describe('redis.ts — single-source connection module', () => {
     expect(mod.getRedis()).toBe(mod.getRedis());
     mod.__setRedisClientForTests(null);
   });
+
+  it('redisTarget mirrors the resolved connection and is frozen', async () => {
+    process.env.REDIS_HOST = 'redis.svc.cluster.local';
+    process.env.REDIS_PORT = '6380';
+    const mod = await import('./redis');
+    expect(mod.redisTarget).toEqual({ host: 'redis.svc.cluster.local', port: 6380 });
+    expect(mod.bullmqConnection.host).toBe(mod.redisTarget.host);
+    expect(Object.isFrozen(mod.redisTarget)).toBe(true);
+  });
 });

--- a/packages/deces-backend/src/redis.ts
+++ b/packages/deces-backend/src/redis.ts
@@ -37,6 +37,16 @@ const target = {
   port: Number(process.env.REDIS_PORT) || 6379,
 };
 
+// Exposed so startup can log the resolved target. The OTP-vs-BullMQ divergence
+// bug (OTP read REDIS_HOST while BullMQ hardcoded 'redis') was invisible at
+// runtime; logging the single resolved target at boot makes a misconfigured
+// REDIS_HOST obvious in the deploy logs instead of surfacing as silent retries.
+export const redisTarget: Readonly<{ host: string; port: number }> = Object.freeze({ ...target });
+
+export const logRedisTarget = (): void => {
+  log({ info: 'Redis target resolved', host: redisTarget.host, port: redisTarget.port });
+};
+
 // Plain-command client (OTP / cache): bounded retries so a request fails fast on
 // outage, while ioredis auto-reconnects in the background so the backend recovers
 // on its own when Redis comes back.


### PR DESCRIPTION
Logs the single resolved Redis target (host:port) once at backend startup.

## Why
The OTP-vs-BullMQ divergence fixed in #72 (OTP read `REDIS_HOST` while BullMQ hardcoded `'redis'`) was invisible at runtime — a misconfigured `REDIS_HOST` would surface only as silent retries. Logging the resolved target at boot makes it obvious in the deploy logs.

Also: this is the change that triggers the backend image (re)publish on merge — #72 was merged with `[skip ci]`, so its image (`1.0.0-353b5c`) was never built; merging this PR **without** `[skip ci]` runs the push-CD that publishes the backend image and deploys dev.

## What
- `redis.ts`: export frozen `redisTarget` + `logRedisTarget()`.
- `index.ts`: call `logRedisTarget()` once after `listen`.
- `redis.spec.ts`: assert `redisTarget` mirrors the connection and is frozen.

## Tests
- `redis.spec.ts` 4/4, `tsc --noEmit` clean, `eslint` 0 errors.

## Merge note
Merge **without** `[skip ci]` so the push-CD publishes the backend image; the merge will auto-deploy dev.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Redis configuration logging during server startup for improved deployment visibility.

* **Tests**
  * Added verification test for Redis connection configuration and immutability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/matchID-project/matchID/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->