### PR TITLE
fix(k8s): Traefik router entrypoints+tls annotations on dev/test ingresses

### DIFF
--- a/deploy/k8s/overlays/dev/ingress.dev.yaml
+++ b/deploy/k8s/overlays/dev/ingress.dev.yaml
@@ -1,10 +1,17 @@
 # Dev overlay : public hostname behind cert-manager-issued TLS.
+#
+# Traefik v3 with the k8s Ingress provider does not auto-bind ingresses with
+# a `tls:` section to the websecure entrypoint; HTTPS requests 404 even with
+# a valid cert. The explicit `router.entrypoints` + `router.tls` annotations
+# force the router to register on both web and websecure.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: deces
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   tls:

--- a/deploy/k8s/overlays/test/ingress.test.yaml
+++ b/deploy/k8s/overlays/test/ingress.test.yaml
@@ -1,10 +1,17 @@
 # Test overlay : public hostname behind cert-manager-issued TLS.
+#
+# Traefik v3 with the k8s Ingress provider does not auto-bind ingresses with
+# a `tls:` section to the websecure entrypoint; HTTPS requests 404 even with
+# a valid cert. The explicit `router.entrypoints` + `router.tls` annotations
+# force the router to register on both web and websecure.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: deces
   annotations:
     cert-manager.io/cluster-issuer: letsencrypt-prod
+    traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
 spec:
   ingressClassName: traefik
   tls:


### PR DESCRIPTION
## Summary

Persists in the repo a fix I had to apply live on the poc cluster while bringing `test.deces.matchid.io` up over HTTPS for the first time.

Traefik v3 with the k8s Ingress provider **does not auto-bind** ingresses carrying a `tls:` section to the `websecure` entrypoint — so HTTPS requests return 404 even after cert-manager has issued a valid Let's Encrypt cert. The fix is two well-known Traefik annotations on the ingress :

```yaml
traefik.ingress.kubernetes.io/router.entrypoints: web,websecure
traefik.ingress.kubernetes.io/router.tls: "true"
```

Applied to `overlays/dev/ingress.dev.yaml` and `overlays/test/ingress.test.yaml`.

## Validation

Live on the poc cluster after applying these annotations to the matchid-test ingress :

```
$ curl https://test.deces.matchid.io/deces/api/v1/readiness
{"msg":"OK","dependencies":{"elasticsearch":true,"redis":true}}
HTTP 200
```

Without the annotations, the same call returned HTTP 404 — cert handshake succeeded, but no router was bound on websecure.

## Related

Companion changes that should also land in `rhanka/k8s-ops` (separate PR, will link once opened) :
- ClusterIssuer `letsencrypt-prod` solver for the `matchid.io` zone (currently only `sent-tech.ca` is configured).
- NetworkPolicy `allow-traefik-acme-solver` in `tenants/matchid-dev/30-netpol.yaml` and `tenants/matchid-test/30-netpol.yaml` (the default `allow-traefik` policy only matches `deces-backend` / `deces-ui` selectors, blocking the ACME http01 solver pod that cert-manager spawns during the challenge).

## Test plan

- [x] `kubectl kustomize` clean on overlays/dev and overlays/test.
- [x] HTTPS reaches deces-backend on the live cluster (output above).
- [ ] Next `cd-k8s.yml deploy_target=test` keeps HTTPS green after the platform PRs above land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced Kubernetes Ingress configurations for development and test environments to improve HTTPS routing and TLS certificate handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->