### PR TITLE
feat(k8s): matchid-test long-lived (drop burst mode)

### DIFF
--- a/.github/workflows/cd-k8s.yml
+++ b/.github/workflows/cd-k8s.yml
@@ -127,16 +127,6 @@ jobs:
           kubectl kustomize "$overlay_dir" >/tmp/matchid-k8s-rendered.yaml
           kubectl apply -f /tmp/matchid-k8s-rendered.yaml
 
-      - name: Scale test target up
-        if: env.REQUESTED_TARGET == 'test'
-        run: |
-          set -euo pipefail
-          kubectl -n "$NAMESPACE" scale deploy/redis --replicas=1
-          kubectl -n "$NAMESPACE" wait --for=condition=Available --timeout=3m deploy/redis
-          kubectl -n "$NAMESPACE" scale statefulset/elasticsearch --replicas=1
-          kubectl -n "$NAMESPACE" rollout status statefulset/elasticsearch --timeout=10m
-          kubectl -n "$NAMESPACE" scale deploy/deces-backend deploy/deces-ui --replicas=1
-
       - name: Wait for runtime
         run: |
           set -euo pipefail
@@ -171,9 +161,3 @@ jobs:
           kubectl -n "$NAMESPACE" get events --sort-by=.lastTimestamp | tail -80 || true
           kubectl -n "$NAMESPACE" describe pods | tail -160 || true
           kubectl -n "$NAMESPACE" logs -l app.kubernetes.io/part-of=matchid --all-containers=true --tail=200 || true
-
-      - name: Scale test target down
-        if: always() && env.REQUESTED_TARGET == 'test'
-        run: |
-          kubectl -n "$NAMESPACE" scale deploy/deces-backend deploy/deces-ui deploy/redis --replicas=0 || true
-          kubectl -n "$NAMESPACE" scale statefulset/elasticsearch --replicas=0 || true

--- a/deploy/k8s/overlays/test/deces-backend.test.yaml
+++ b/deploy/k8s/overlays/test/deces-backend.test.yaml
@@ -3,11 +3,9 @@ kind: Deployment
 metadata:
   name: deces-backend
 spec:
-  replicas: 0
+  replicas: 1
   template:
     spec:
-      nodeSelector:
-        k8s.scaleway.com/pool-name: burst
       containers:
         - name: deces-backend
           env:
@@ -15,3 +13,7 @@ spec:
               value: test.deces.matchid.io
             - name: APP_URL
               value: https://test.deces.matchid.io
+          envFrom:
+            - secretRef:
+                name: deces-backend-secrets
+                optional: false

--- a/deploy/k8s/overlays/test/deces-ui.test.yaml
+++ b/deploy/k8s/overlays/test/deces-ui.test.yaml
@@ -3,8 +3,4 @@ kind: Deployment
 metadata:
   name: deces-ui
 spec:
-  replicas: 0
-  template:
-    spec:
-      nodeSelector:
-        k8s.scaleway.com/pool-name: burst
+  replicas: 1

--- a/deploy/k8s/overlays/test/elasticsearch.test.yaml
+++ b/deploy/k8s/overlays/test/elasticsearch.test.yaml
@@ -3,11 +3,7 @@ kind: StatefulSet
 metadata:
   name: elasticsearch
 spec:
-  replicas: 0
-  template:
-    spec:
-      nodeSelector:
-        k8s.scaleway.com/pool-name: burst
+  replicas: 1
   volumeClaimTemplates:
     - metadata:
         name: data

--- a/deploy/k8s/overlays/test/redis.test.yaml
+++ b/deploy/k8s/overlays/test/redis.test.yaml
@@ -3,8 +3,4 @@ kind: Deployment
 metadata:
   name: redis
 spec:
-  replicas: 0
-  template:
-    spec:
-      nodeSelector:
-        k8s.scaleway.com/pool-name: burst
+  replicas: 1


### PR DESCRIPTION
## Summary

Drops the burst-only contract on `matchid-test`. The 404 between UAT runs (replicas: 0 at rest) was a poor user experience, and the intent for this env is to be renamed `matchid-prod` and serve `deces.matchid.io` 24/7 once the migration is complete.

`matchid-test` now mirrors `matchid-dev` operationally:
- `replicas: 1` always-on for backend, ui, redis, elasticsearch.
- No more `nodeSelector: pool=burst` — schedules on the default DEV1-M pool (same as dev).
- `deces-backend-secrets` `optional: false` (fail-fast on misprovision), like dev.

`cd-k8s.yml` is simplified: the "Scale test target up" and "Scale test target down" steps are dropped. `kubectl apply -k overlays/test/` alone now brings the stack to the right replica count.

## Companion PR

[rhanka/k8s-ops PR — pending](TBD) updates :
- `tenants/matchid-test/00-namespace.yaml` quota envelope to the long-lived profile (mirror matchid-dev: `requests.cpu=1, requests.memory=2Gi, pods=8`).
- `requests/matchid.md` amendment to record the burst → long-lived transition (and the rename-to-prod intent).

## Validation

- [x] `kubectl kustomize deploy/k8s/overlays/test/` clean.
- [ ] After merge + companion poc-k8s PR : `gh workflow run cd-k8s.yml -f deploy_target=test` → `https://test.deces.matchid.io/deces/api/v1/readiness` returns 200 between runs (no 404).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Test environment services now continuously run with 1 replica instead of being scaled down to zero
  * Simplified CI/CD workflow to directly apply deployments without scaling operations
  * Backend service now properly configured to load environment variables from secrets

<!-- end of auto-generated comment: release notes by coderabbit.ai -->