### PR TITLE
fix(k8s): point backend env at baked-in data files (fix /search crash)

### DIFF
--- a/deploy/k8s/base/deces-backend.deployment.yaml
+++ b/deploy/k8s/base/deces-backend.deployment.yaml
@@ -78,17 +78,20 @@ spec:
               value: "5"
             - name: BACKEND_TMP_WINDOW
               value: "60"
-            # File paths read at import time (mail.ts, communes.ts, etc.).
-            # Pointing at /dev/null lets the requires return empty data and
-            # log a soft warning rather than crash.
+            # Reference data baked into the image by the deces-backend build
+            # (Dockerfile `COPY ${DATA_DIR} ./data` step). Pointing at
+            # /dev/null instead silently returns empty arrays at import time
+            # but then crashes `/search` enrichment in models/result.ts on
+            # the very first hit (TypeError: Cannot read properties of
+            # undefined (reading '<wikidata id>')).
             - name: DISPOSABLE_MAIL
-              value: /dev/null
+              value: /deces-backend/data/disposable-mail.txt
             - name: COMMUNES_JSON
-              value: /dev/null
+              value: /deces-backend/data/communes.json
             - name: DB_JSON
-              value: /dev/null
+              value: /deces-backend/data/userDB.json
             - name: WIKIDATA_LINKS
-              value: /dev/null
+              value: /deces-backend/data/wikidata.json
             # BullMQ Redis broker
             - name: REDIS_HOST
               value: redis


### PR DESCRIPTION
## Summary

The deces-backend env block in `deploy/k8s/base/deces-backend.deployment.yaml` was pointing `DISPOSABLE_MAIL`, `COMMUNES_JSON`, `DB_JSON`, `WIKIDATA_LINKS` at `/dev/null` with the comment that the import-time loads would "log a soft warning rather than crash".

Discovered while bringing data into matchid-dev today : that assumption is wrong. `wikidata.ts`, `userDB.ts` etc. keep their parsed dictionary in module scope, and `models/result.ts:111` reads `wikidata[id].*` without a nil-check. So `/search` crashes on the very first real hit :

```
TypeError: Cannot read properties of undefined (reading 'La_tHGE_y86K')
  at buildResultSingle (/deces-backend/dist/models/result.js:111:35)
```

The Dockerfile already bakes the reference data into the image (`COPY ${DATA_DIR} ./data`, see `packages/deces-backend/Dockerfile:100`). The runtime files are at `/deces-backend/data/`. The fix is just to point the env vars at those existing paths.

## Validation

After restoring the production ES snapshot into matchid-dev (60 557 docs in the `deces` index), and applying this patch locally :

```
$ curl https://dev.deces.matchid.io/deces/api/v1/version
{"uniqRecordsCount":60557,"lastRecordDate":"30/01/2020","lastDataset":"2020-m01"}

$ curl -X POST -H 'Content-Type: application/json' \
  -d '{"firstName":"jean","size":1}' \
  https://dev.deces.matchid.io/deces/api/v1/search
# expected after this PR: real result + wikidata enrichment, no 500.
```

## Test plan

- [x] `kubectl kustomize` clean on overlays/dev and overlays/test.
- [ ] After merge + `cd-k8s` redeploy on dev : `/search firstName=jean size=1` returns 1 result with no 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)