### PR TITLE
fix(k8s): backend memory 256/512 → 512/1Gi (avoid OOM on JSON load)

### DIFF
--- a/deploy/k8s/base/deces-backend.deployment.yaml
+++ b/deploy/k8s/base/deces-backend.deployment.yaml
@@ -140,10 +140,14 @@ spec:
           resources:
             requests:
               cpu: 100m
-              memory: 256Mi
+              # communes.json (~60 MB) + wikidata.json (~9 MB) are loaded
+              # at startup. After V8 parses them and keeps them in module
+              # scope as objects, the resident set sits well above 512 MiB,
+              # which used to OOM the container on the first /search hit.
+              memory: 512Mi
             limits:
               cpu: 500m
-              memory: 512Mi
+              memory: 1Gi
       volumes:
         - name: data
           emptyDir: {}


### PR DESCRIPTION
Companion to PR #80 (data file paths). Once the backend actually reads communes.json (~60 MB) + wikidata.json (~9 MB) into module-scope dictionaries, the resident set sits well above the previous 512 MiB limit and the container OOMs on the first /search hit (FATAL ERROR: Reached heap limit). Bumps to 512 MiB request / 1 GiB limit. Validated live on matchid-dev — /search returns 5 943 results for firstName=jean.