### PR TITLE
fix(k8s): prod-class sizing for matchid-test + APP_VERSION env

### DIFF
--- a/deploy/k8s/base/deces-backend.deployment.yaml
+++ b/deploy/k8s/base/deces-backend.deployment.yaml
@@ -45,6 +45,14 @@ spec:
           env:
             - name: NODE_ENV
               value: production
+            # status.controller.ts:/version returns `backend: process.env.APP_VERSION`.
+            # The UI reads that field as `$version.api` and the badge goes red
+            # ("API indisponible (êtes vous hors ligne ?)") if it is falsy,
+            # even when the /version call itself succeeded. Hardcoding a value
+            # here keeps the badge green; cd-k8s.yml can override at deploy
+            # time when an image-tag-derived version is wanted.
+            - name: APP_VERSION
+              value: "1.0.0-k8s"
             - name: BACKEND_PORT
               value: "8080"
             - name: APP

--- a/deploy/k8s/overlays/test/deces-backend.test.yaml
+++ b/deploy/k8s/overlays/test/deces-backend.test.yaml
@@ -6,6 +6,11 @@ spec:
   replicas: 1
   template:
     spec:
+      # matchid-test mirrors the prod VM (GP1-XS = 4 vCPU / 16 GiB) on the
+      # POP2-4C-16G burst pool. The burst pool is the matchID prod-class
+      # workload target and is reserved by quota for this tenant.
+      nodeSelector:
+        k8s.scaleway.com/pool-name: burst
       containers:
         - name: deces-backend
           env:
@@ -17,3 +22,15 @@ spec:
             - secretRef:
                 name: deces-backend-secrets
                 optional: false
+          # NewRelic 7-day baseline on the prod VM shows the Node process at
+          # max 75 % of one vCPU and 582 MiB RSS. Limits give comfortable
+          # headroom; the base 512 Mi / 1 GiB sizing is enough for steady
+          # state but bumps to 1 GiB / 2 GiB here so a slow GC pause under
+          # full-corpus load does not OOM.
+          resources:
+            requests:
+              cpu: 200m
+              memory: 1Gi
+            limits:
+              cpu: 1500m
+              memory: 2Gi

--- a/deploy/k8s/overlays/test/deces-ui.test.yaml
+++ b/deploy/k8s/overlays/test/deces-ui.test.yaml
@@ -4,3 +4,7 @@ metadata:
   name: deces-ui
 spec:
   replicas: 1
+  template:
+    spec:
+      nodeSelector:
+        k8s.scaleway.com/pool-name: burst

--- a/deploy/k8s/overlays/test/elasticsearch.test.yaml
+++ b/deploy/k8s/overlays/test/elasticsearch.test.yaml
@@ -4,6 +4,27 @@ metadata:
   name: elasticsearch
 spec:
   replicas: 1
+  template:
+    spec:
+      nodeSelector:
+        k8s.scaleway.com/pool-name: burst
+      containers:
+        - name: elasticsearch
+          env:
+            # Heap sized for the full INSEE corpus (~27 M docs). NewRelic 7-day
+            # baseline on the prod VM shows the Java process at 5.1 GiB RSS
+            # average / 13 GiB peak, with bursts to 367 % of one vCPU. Heap is
+            # kept below 50 % of the limit so Lucene memory-mapped files have
+            # room in the OS page cache (the ES recommendation).
+            - name: ES_JAVA_OPTS
+              value: "-Xms6g -Xmx6g"
+          resources:
+            requests:
+              cpu: 1500m
+              memory: 6Gi
+            limits:
+              cpu: 3500m
+              memory: 13Gi
   volumeClaimTemplates:
     - metadata:
         name: data
@@ -12,4 +33,6 @@ spec:
         storageClassName: scw-bssd
         resources:
           requests:
-            storage: 5Gi
+            # Full snapshot from the prod bucket is ~6 GiB; +headroom for
+            # background segment merges and translog.
+            storage: 20Gi

--- a/deploy/k8s/overlays/test/redis.test.yaml
+++ b/deploy/k8s/overlays/test/redis.test.yaml
@@ -4,3 +4,7 @@ metadata:
   name: redis
 spec:
   replicas: 1
+  template:
+    spec:
+      nodeSelector:
+        k8s.scaleway.com/pool-name: burst


### PR DESCRIPTION
## Summary

Two fixes that landed together because the second was discovered while sizing the first.

### 1. matchid-test back to prod-class (companion PR k8s-ops will land the quota)

Earlier I had moved `matchid-test` off the burst pool and reused the `matchid-dev` sizing profile (1 GiB / 4 GiB envelope, default DEV1-M pool). That was wrong: `matchid-test` is on the rollover path to `matchid-prod` (target `deces.matchid.io`) and must already share the operational characteristics of the production VM `matchid-deces-ui-master` (Scaleway GP1-XS = 4 vCPU / 16 GiB).

Sizing is grounded in 7 days of NewRelic `SystemSample` + `ProcessSample` on the prod VM :

| Process | avg CPU% | max CPU% | avg RSS | max RSS |
|---|---|---|---|---|
| java (ES) | 30 % | **367 %** of one vCPU | 5.1 GiB | **13.0 GiB** |
| node (deces-backend) | 4.5 % | 75 % | 190 MiB | **582 MiB** |

Translated into matchid-test (pinned to `k8s.scaleway.com/pool-name=burst`, POP2-4C-16G = same flavor as GP1-XS) :

- **elasticsearch** : request 1500m / 6 Gi, limit 3500m / 13 Gi, `-Xms6g -Xmx6g` (heap < 50 % of limit so Lucene mmap has room in the page cache).
- **deces-backend** : request 200m / 1 Gi, limit 1500m / 2 Gi (1 Gi headroom over observed 582 MiB max for full-corpus search bursts).
- **redis / ui** : unchanged from base, just inherit the burst pool nodeSelector.
- **PV** : 5 Gi → 20 Gi (full snapshot is ~6 Gi compressed on S3, +headroom for merges and translog).

### 2. UI badge "API indisponible (êtes-vous hors ligne ?)"

The UI was showing the red "API hors ligne" banner even when `/version` itself returned 200. Root cause traced through the source :

```js
// packages/deces-ui/src/App.svelte:34
const r = await fetch('__BACKEND_PROXY_PATH__/version');
const json = await r.json();
$version.api = json.backend;
```

```svelte
// packages/deces-ui/src/components/views/PunchMessage.svelte:31
{#if $version.api}
  -api/{$version.api}
{:else}
  <strong class="rf-color--rm">API indisponible (êtes vous hors ligne ?) </strong>
{/if}
```

`json.backend` comes from `packages/deces-backend/src/controllers/status.controller.ts:89` :

```ts
backend: process.env.APP_VERSION,
```

The Deployment never set `APP_VERSION`, so the field was `undefined` and the badge was permanently red. Hardcoded a literal `1.0.0-k8s` in the base Deployment; cd-k8s.yml can later override at deploy time when an image-tag-derived version is wanted.

## Companion PR

`rhanka/k8s-ops` PR (pending) grows the `matchid-test` tenant quota :

- requests.cpu 1 → **2**, requests.memory 2 Gi → **9 Gi**, limits.cpu 3 → **5**, limits.memory 4 Gi → **14 Gi**, persistentvolumeclaims 4 (unchanged).

This pins ~one POP2-4C-16G burst-pool node to matchid-test (~50-60 €/month always-on).

## Validation

- [x] `kubectl kustomize` clean on base, overlays/local, overlays/dev, overlays/test.
- [ ] After both PRs merge + ES full-snapshot restore + redeploy : `https://test.deces.matchid.io/deces/api/v1/search firstName=jean` returns full-corpus results (≫ 5 943 hits from the 2020-m01 slice), and the UI banner no longer shows "API indisponible".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes deployment configurations for the test environment to improve resource management and scheduling.
  * Configured resource requests and limits for backend services.
  * Enhanced storage allocation for data persistence.
  * Optimized Java heap memory configuration for search infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->