### PR TITLE
fix(k8s/test): bump ES PV 20Gi -> 30Gi

### DIFF
--- a/deploy/k8s/overlays/test/elasticsearch.test.yaml
+++ b/deploy/k8s/overlays/test/elasticsearch.test.yaml
@@ -35,4 +35,4 @@ spec:
           requests:
             # Full snapshot from the prod bucket is ~6 GiB; +headroom for
             # background segment merges and translog.
-            storage: 20Gi
+            storage: 30Gi


### PR DESCRIPTION
Companion to PR #82 (prod-class sizing). The full prod snapshot is 15 GiB on S3; 20 GiB PV (after ext4 overhead and headroom for merges+translog) was too tight. 30 GiB is comfortable and supports the next monthly snapshot without a second resize.