### PR TITLE
fix(art85): cnil article 85 removal for /id/MRJbFpR1f1iR

### DIFF
--- a/packages/deces-ui/src/components/tools/dataCorrections.js
+++ b/packages/deces-ui/src/components/tools/dataCorrections.js
@@ -320,4 +320,12 @@ export const dataCorrections = {
     "proofs": ["none"],
     "anonymize": true
   },
+  "MRJbFpR1f1iR": {
+    "permalink": "/id/MRJbFpR1f1iR",
+    "change": "remove",
+    "request": "child",
+    "reason": "cnil-art-85",
+    "proofs": ["none"],
+    "anonymize": true
+  },
 };


### PR DESCRIPTION
## Article 85 (loi Informatique et Libertés) — suppression

Ajoute une correction `remove` + `anonymize` pour `/id/MRJbFpR1f1iR`, afin que la fiche soit masquée/anonymisée sur deces.matchid.io.

- `request`: child
- `proofs`: none (comme la plupart des demandes)
- `reason`: cnil-art-85

Entrée dans `packages/deces-ui/src/components/tools/dataCorrections.js`, au même format que les entrées existantes (cf. PR #19). Le module parse (41 entrées).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data correction rules to handle additional correction scenarios with privacy-compliant data removal and anonymization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->